### PR TITLE
Add Unikittyville game to the website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ jobs:
       - name: 🏗️ Build site
         run: npm run build
 
-      - name: Clean S3 bucket before deploy (preserve podcast audio)
-        run: aws s3 rm s3://norahtashner.com --recursive --exclude "podcast/*"
+      - name: Clean S3 bucket before deploy (preserve podcast audio and game assets)
+        run: aws s3 rm s3://norahtashner.com --recursive --exclude "podcast/*" --exclude "games/unikittyville/assets/*"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -35,7 +35,7 @@ jobs:
       - name: 🚀 Sync to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --follow-symlinks --delete --exclude "podcast/*"
+          args: --follow-symlinks --delete --exclude "podcast/*" --exclude "games/unikittyville/assets/*"
         env:
           AWS_S3_BUCKET: norahtashner.com
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/public/games/unikittyville/index.html
+++ b/public/games/unikittyville/index.html
@@ -1,0 +1,4537 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Unikittyville</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #1a1a2e;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    overflow: hidden;
+  }
+  #startScreen {
+    position: fixed;
+    inset: 0;
+    background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 50%, #a18cd1 100%);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 100;
+  }
+  #startScreen h1 {
+    font-size: 4rem;
+    color: #fff;
+    text-shadow: 3px 3px 0 #c084fc, 6px 6px 0 #7c3aed;
+    margin-bottom: 0.5rem;
+    letter-spacing: 2px;
+  }
+  #startScreen .subtitle {
+    font-size: 1.2rem;
+    color: #fff;
+    opacity: 0.9;
+    margin-bottom: 2rem;
+  }
+  #startScreen label {
+    font-size: 1.2rem;
+    color: #fff;
+    margin-bottom: 0.5rem;
+  }
+  #nameInput {
+    font-size: 1.5rem;
+    padding: 12px 24px;
+    border: 3px solid #c084fc;
+    border-radius: 16px;
+    outline: none;
+    text-align: center;
+    background: rgba(255,255,255,0.9);
+    color: #4c1d95;
+    width: 300px;
+    margin-bottom: 1.5rem;
+  }
+  #nameInput:focus { border-color: #7c3aed; box-shadow: 0 0 20px rgba(124,58,237,0.3); }
+  #startBtn {
+    font-size: 1.3rem;
+    padding: 14px 48px;
+    background: linear-gradient(135deg, #7c3aed, #c084fc);
+    color: #fff;
+    border: none;
+    border-radius: 16px;
+    cursor: pointer;
+    font-weight: 700;
+    letter-spacing: 1px;
+    transition: transform 0.15s, box-shadow 0.15s;
+  }
+  #startBtn:hover { transform: scale(1.05); box-shadow: 0 8px 25px rgba(124,58,237,0.4); }
+  canvas { border-radius: 12px; display: block; }
+  #hud {
+    position: fixed;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    gap: 24px;
+    background: rgba(255,255,255,0.15);
+    backdrop-filter: blur(12px);
+    padding: 10px 28px;
+    border-radius: 20px;
+    border: 1px solid rgba(255,255,255,0.25);
+    font-size: 1.05rem;
+    color: #fff;
+    font-weight: 600;
+    z-index: 10;
+  }
+  #hud span { display: flex; align-items: center; gap: 6px; }
+  #controls {
+    position: fixed;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    background: rgba(255,255,255,0.12);
+    backdrop-filter: blur(12px);
+    padding: 8px 20px;
+    border-radius: 14px;
+    border: 1px solid rgba(255,255,255,0.2);
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.8);
+    z-index: 10;
+    gap: 16px;
+  }
+  #prompt {
+    position: fixed;
+    bottom: 80px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    background: rgba(0,0,0,0.7);
+    backdrop-filter: blur(8px);
+    padding: 10px 24px;
+    border-radius: 12px;
+    font-size: 1.1rem;
+    color: #fde68a;
+    font-weight: 600;
+    z-index: 10;
+    white-space: nowrap;
+  }
+</style>
+</head>
+<body>
+
+<audio id="musicMeadow" src="assets/music/theme.mp3" loop preload="auto"></audio>
+<audio id="musicNYC" src="assets/music/city.mp3" loop preload="auto"></audio>
+<audio id="musicRome" src="assets/music/rome.mp3" loop preload="auto"></audio>
+<audio id="musicHawaii" src="assets/music/hawaii.mp3" loop preload="auto"></audio>
+<audio id="musicAlps" src="assets/music/alps.mp3" loop preload="auto"></audio>
+<audio id="meow1" src="assets/sfx/kitty-meow-01.mp3" preload="auto"></audio>
+<audio id="meow2" src="assets/sfx/kitty-meow-02.mp3" preload="auto"></audio>
+<audio id="chaChing" src="assets/sfx/cha-ching.mp3" preload="auto"></audio>
+
+<div id="startScreen">
+  <h1>Unikittyville</h1>
+  <div class="subtitle">A Unicorn Kitty Adventure</div>
+  <label for="nameInput">Name your kitty:</label>
+  <input type="text" id="nameInput" placeholder="Sparkle" maxlength="16" autofocus>
+  <button id="startBtn">Play!</button>
+</div>
+
+<canvas id="game"></canvas>
+<div id="hud">
+  <span id="hudLevel">Level 1</span>
+  <span id="hudName"></span>
+  <span>Score: <b id="hudScore">0</b></span>
+  <span>Fish: <b id="hudFish">0</b></span>
+  <span>Bacon: <b id="hudBacon">0</b></span>
+  <span>Yarn: <b id="hudYarn">0</b></span>
+  <span>Pizza: <b id="hudPizza">0</b></span>
+  <span>Hot Dogs: <b id="hudHotdog">0</b></span>
+  <span>Gelato: <b id="hudGelato">0</b></span>
+  <span>Honey: <b id="hudHoney">0</b></span>
+  <span>Tiki: <b id="hudTiki">0</b></span>
+  <span>Coconuts: <b id="hudCoconut">0</b></span>
+  <span>Diamonds: <b id="hudDiamond">0</b></span>
+</div>
+<div id="controls">
+  <span>Arrow Keys: Move</span>
+  <span>Space: Jump</span>
+  <span>F: Fish</span>
+  <span>C: Cook</span>
+  <span>H: Honey</span>
+  <span>T: Tiki</span>
+  <span>Enter: Enter/Exit Buildings</span>
+</div>
+<div id="prompt"></div>
+
+<script>
+// ── Constants ──
+const WORLD_W = 4800;
+const GROUND_Y = 420;
+const GRAVITY = 0.6;
+const JUMP_VEL = -12;
+const MOVE_SPEED = 4;
+const DAY_LENGTH = 30000; // 30s full cycle
+
+// Zone positions in world coords
+const POND = { x: 200, w: 400, depth: 80 };
+const GRILL = { x: 1000, w: 60 };
+const HOUSE = { x: 1600, w: 160, h: 160 };
+
+// ── State ──
+let playerName = 'Sparkle';
+let score = 0, fishCount = 0, baconCount = 0, yarnCount = 0;
+let gameTime = 0;
+let insideHouse = false;
+let insidePizza = false;
+let insideCamper = false;
+let insideWindmill = false;
+let cooking = { active: false, progress: 0, burnt: false };
+let fishing = { active: false, timer: 0, caught: false };
+let honeyCount = 0;
+let pizzaMaking = { active: false, progress: 0, stage: 'idle', pizzaCount: 0 };
+const PIZZA_SHOP = { x: 1000, w: 80 };
+let insidePark = false;
+let hotdogCount = 0;
+const HOTDOG_POSITIONS = [600, 2000, 3400];
+const CENTRAL_PARK_POS = { x: 2200, w: 160 };
+const TAXI_POSITIONS = [300, 1200, 2400, 3600];
+// Rome interactions
+let insidePantheon = false;
+let swimming = false;
+let gelatoCount = 0;
+const FOUNTAIN_POS = { x: 1500 };
+const GELATO_POSITIONS = [1000, 2800];
+const PANTHEON_POS = { x: 2600 };
+const FIAT_POS = { x: 4500 };
+// Hawaii interactions
+let tikiCount = 0;
+let coconutCount = 0;
+let surfing = false;
+const TIKI_POSITIONS = [600, 1400, 2200, 3000, 3800];
+const COCONUT_POSITIONS = [400, 1200, 2000, 2800, 3600, 4400];
+const SURF_POS = { x: 1800 };
+let popups = []; // floating score popups
+let keys = {};
+let lastMeowTime = 0;
+let lastChaChingTime = 0;
+let currentLevel = 1;
+let levelTransition = { active: false, timer: 0, toLevel: 0 };
+const meowSounds = [];
+let chaChingSound = null;
+
+function initMeows() {
+  meowSounds.push(document.getElementById('meow1'));
+  meowSounds.push(document.getElementById('meow2'));
+  for (const m of meowSounds) m.volume = 0.5;
+  chaChingSound = document.getElementById('chaChing');
+  chaChingSound.volume = 0.5;
+}
+
+function playChaChing() {
+  const now = performance.now();
+  if (now - lastChaChingTime < 2000) return;
+  lastChaChingTime = now;
+  chaChingSound.currentTime = 0;
+  chaChingSound.play().catch(() => {});
+}
+
+function playMeow() {
+  const now = performance.now();
+  if (now - lastMeowTime < 3000) return;
+  lastMeowTime = now;
+  const sound = meowSounds[Math.floor(Math.random() * meowSounds.length)];
+  sound.currentTime = 0;
+  sound.play().catch(() => {});
+}
+
+// ── Music system with crossfade ──
+const MUSIC_VOLUME = 0.4;
+const FADE_DURATION = 1200; // ms
+const levelMusic = { 1: 'musicMeadow', 2: 'musicNYC', 3: 'musicRome', 4: 'musicHawaii', 5: 'musicAlps' };
+let currentMusicId = null;
+let musicFade = null; // { out: AudioElement, in: AudioElement, timer: 0 }
+
+function startLevelMusic(level) {
+  const id = levelMusic[level];
+  if (!id || id === currentMusicId) return;
+  const el = document.getElementById(id);
+  el.volume = MUSIC_VOLUME;
+  el.currentTime = 0;
+  el.play().catch(() => {});
+  currentMusicId = id;
+}
+
+function crossfadeToLevel(level) {
+  const newId = levelMusic[level];
+  if (!newId || newId === currentMusicId) return;
+  const outEl = currentMusicId ? document.getElementById(currentMusicId) : null;
+  const inEl = document.getElementById(newId);
+  inEl.volume = 0;
+  inEl.currentTime = 0;
+  inEl.play().catch(() => {});
+  musicFade = { out: outEl, inEl: inEl, inId: newId, timer: 0 };
+}
+
+function updateMusicFade(dt) {
+  if (!musicFade) return;
+  musicFade.timer += dt;
+  const t = Math.min(1, musicFade.timer / FADE_DURATION);
+  if (musicFade.out) musicFade.out.volume = MUSIC_VOLUME * (1 - t);
+  musicFade.inEl.volume = MUSIC_VOLUME * t;
+  if (t >= 1) {
+    if (musicFade.out) { musicFade.out.pause(); musicFade.out.currentTime = 0; }
+    currentMusicId = musicFade.inId;
+    musicFade = null;
+  }
+}
+
+// Player
+const player = {
+  x: 600, y: GROUND_Y, vx: 0, vy: 0,
+  w: 40, h: 48,
+  onGround: true,
+  facing: 1, // 1 right, -1 left
+  walkFrame: 0, walkTimer: 0,
+  color: '#e879f9' // pink-purple
+};
+
+// Fish in pond
+let pondFish = [];
+function spawnPondFish() {
+  pondFish = [];
+  const colors = ['#fb923c','#38bdf8','#4ade80','#f472b6'];
+  for (let i = 0; i < 5; i++) {
+    pondFish.push({
+      x: POND.x + 40 + Math.random() * (POND.w - 80),
+      y: GROUND_Y + 10 + Math.random() * (POND.depth - 30),
+      vx: (Math.random() - 0.5) * 1.5,
+      color: colors[i % colors.length],
+      size: 14 + Math.random() * 8,
+      wobble: Math.random() * Math.PI * 2
+    });
+  }
+}
+spawnPondFish();
+
+// NPCs
+const npcs = [];
+const npcColors = ['#86efac','#c4b5fd','#fdba74','#7dd3fc'];
+const npcAccessories = ['bow','scarf','glasses','flower'];
+for (let i = 0; i < 4; i++) {
+  npcs.push({
+    x: 300 + i * 450 + Math.random() * 100,
+    y: GROUND_Y,
+    color: npcColors[i],
+    accessory: npcAccessories[i],
+    vx: (Math.random() - 0.5) * 1.2,
+    walkFrame: 0, walkTimer: 0,
+    facing: 1,
+    idleTimer: Math.random() * 200
+  });
+}
+
+// Platforms — staircase arrangement across the world
+const platforms = [
+  // Pond area platforms (left side)
+  { x: 100, y: 340, w: 90 },
+  { x: 240, y: 290, w: 80 },
+  { x: 400, y: 250, w: 70 },
+  // Middle area platforms
+  { x: 700, y: 340, w: 100 },
+  { x: 850, y: 280, w: 80 },
+  { x: 980, y: 220, w: 90 },
+  { x: 1100, y: 340, w: 80 },
+  // Right side platforms
+  { x: 1300, y: 320, w: 90 },
+  { x: 1450, y: 260, w: 80 },
+  { x: 1600, y: 200, w: 100 },
+  // Far right original
+  { x: 1850, y: 330, w: 90 },
+  { x: 2000, y: 270, w: 80 },
+  { x: 2150, y: 210, w: 90 },
+  // Extended world platforms
+  { x: 2500, y: 340, w: 100 },
+  { x: 2680, y: 280, w: 80 },
+  { x: 2850, y: 220, w: 90 },
+  { x: 3100, y: 330, w: 80 },
+  { x: 3280, y: 260, w: 90 },
+  { x: 3500, y: 340, w: 100 },
+  { x: 3650, y: 280, w: 80 },
+  { x: 3820, y: 210, w: 90 },
+  { x: 4050, y: 320, w: 80 },
+  { x: 4200, y: 250, w: 90 },
+  { x: 4400, y: 340, w: 100 },
+  { x: 4550, y: 270, w: 80 },
+];
+
+// Yarn balls — placed on top of the higher platforms
+const yarnColors = ['#fda4af','#c4b5fd','#a5f3fc','#fde68a','#bbf7d0','#fbcfe8','#ddd6fe'];
+const yarnBalls = [];
+for (const p of platforms) {
+  if (p.y < 300) { // only on higher platforms
+    yarnBalls.push({
+      x: p.x + p.w / 2,
+      y: p.y - 14,
+      color: yarnColors[yarnBalls.length % yarnColors.length],
+      collected: false,
+      bobPhase: Math.random() * Math.PI * 2
+    });
+  }
+}
+
+// Background scenes — decorations that appear as you scroll right
+const bgScenes = [
+  // Camper RVs
+  { type: 'rv', x: 800, color: '#fbbf24' },
+  { type: 'rv', x: 2300, color: '#fb7185' },
+  { type: 'rv', x: 3800, color: '#67e8f9' },
+  // Cacti
+  { type: 'cactus', x: 650, size: 1 },
+  { type: 'cactus', x: 1200, size: 0.8 },
+  { type: 'cactus', x: 2600, size: 1.2 },
+  { type: 'cactus', x: 3400, size: 0.9 },
+  { type: 'cactus', x: 4300, size: 1.1 },
+  // Scene 1: Mushroom grove
+  { type: 'mushroom', x: 1900, count: 4 },
+  // Scene 2: Flower garden
+  { type: 'flowers', x: 2450 },
+  // Scene 3: Campfire with log seating
+  { type: 'campfire', x: 2800 },
+  // Scene 4: Windmill
+  { type: 'windmill', x: 3200 },
+  // Scene 5: Crystal cluster
+  { type: 'crystals', x: 3600 },
+  // Scene 6: Beehive in a tree
+  { type: 'beehive', x: 4000 },
+  // Scene 7: Waterfall rocks
+  { type: 'waterfall', x: 4350 },
+  // Scene 8: Rainbow bridge (portal to Level 2)
+  { type: 'bridge', x: 4600 },
+];
+
+// ── Level 2: New York City ──
+const BRIDGE_PORTAL = { x: 4600, radius: 55 }; // rainbow bridge hitbox
+
+const level2 = {
+  worldW: 4800,
+  platforms: [
+    // Fire escapes & ledges on buildings
+    { x: 150, y: 340, w: 80 },
+    { x: 350, y: 280, w: 90 },
+    { x: 550, y: 330, w: 70 },
+    { x: 700, y: 260, w: 80 },
+    { x: 900, y: 340, w: 100 },
+    { x: 1100, y: 290, w: 80 },
+    { x: 1300, y: 230, w: 90 },
+    { x: 1500, y: 340, w: 80 },
+    { x: 1700, y: 280, w: 90 },
+    { x: 1900, y: 220, w: 80 },
+    { x: 2150, y: 340, w: 100 },
+    { x: 2350, y: 270, w: 80 },
+    { x: 2550, y: 210, w: 90 },
+    { x: 2800, y: 330, w: 80 },
+    { x: 3000, y: 260, w: 90 },
+    { x: 3200, y: 340, w: 100 },
+    { x: 3400, y: 280, w: 80 },
+    { x: 3600, y: 220, w: 90 },
+    { x: 3850, y: 340, w: 80 },
+    { x: 4050, y: 270, w: 90 },
+    { x: 4250, y: 210, w: 80 },
+    { x: 4500, y: 340, w: 100 },
+  ],
+  yarnBalls: [],
+  buildings: [
+    // NYC skyline buildings: x, width, height, color, windows
+    { x: 50, w: 120, h: 250, c: '#64748b', windows: true },
+    { x: 200, w: 80, h: 180, c: '#78716c', windows: true },
+    { x: 310, w: 100, h: 320, c: '#475569', windows: true, spire: true },
+    { x: 450, w: 90, h: 200, c: '#6b7280', windows: true },
+    { x: 580, w: 130, h: 280, c: '#57534e', windows: true },
+    { x: 750, w: 70, h: 160, c: '#71717a', windows: true },
+    { x: 860, w: 110, h: 340, c: '#44403c', windows: true, spire: true },
+    { x: 1010, w: 90, h: 220, c: '#64748b', windows: true },
+    { x: 1140, w: 120, h: 260, c: '#525252', windows: true },
+    { x: 1300, w: 80, h: 190, c: '#78716c', windows: true },
+    { x: 1420, w: 100, h: 300, c: '#475569', windows: true },
+    { x: 1560, w: 110, h: 230, c: '#6b7280', windows: true },
+    { x: 1710, w: 90, h: 350, c: '#44403c', windows: true, spire: true },
+    { x: 1840, w: 120, h: 200, c: '#57534e', windows: true },
+    { x: 2000, w: 80, h: 270, c: '#71717a', windows: true },
+    { x: 2120, w: 130, h: 180, c: '#64748b', windows: true },
+    { x: 2290, w: 100, h: 310, c: '#525252', windows: true, spire: true },
+    { x: 2430, w: 90, h: 220, c: '#78716c', windows: true },
+    { x: 2560, w: 110, h: 250, c: '#475569', windows: true },
+    { x: 2710, w: 80, h: 190, c: '#6b7280', windows: true },
+    { x: 2830, w: 120, h: 280, c: '#44403c', windows: true },
+    { x: 2990, w: 100, h: 340, c: '#57534e', windows: true, spire: true },
+    { x: 3130, w: 90, h: 210, c: '#71717a', windows: true },
+    { x: 3260, w: 110, h: 260, c: '#64748b', windows: true },
+    { x: 3410, w: 80, h: 300, c: '#525252', windows: true },
+    { x: 3530, w: 120, h: 180, c: '#78716c', windows: true },
+    { x: 3690, w: 100, h: 320, c: '#475569', windows: true, spire: true },
+    { x: 3830, w: 90, h: 240, c: '#6b7280', windows: true },
+    { x: 3960, w: 130, h: 200, c: '#44403c', windows: true },
+    { x: 4130, w: 80, h: 280, c: '#57534e', windows: true },
+    { x: 4250, w: 110, h: 350, c: '#525252', windows: true, spire: true },
+    { x: 4400, w: 100, h: 220, c: '#71717a', windows: true },
+  ],
+  scenes: [
+    // NYC-themed scenes
+    { type: 'taxi', x: 300 },
+    { type: 'taxi', x: 1200 },
+    { type: 'taxi', x: 2400 },
+    { type: 'taxi', x: 3600 },
+    { type: 'hotdog_cart', x: 600 },
+    { type: 'hotdog_cart', x: 2000 },
+    { type: 'hotdog_cart', x: 3400 },
+    { type: 'fire_hydrant', x: 180 },
+    { type: 'fire_hydrant', x: 900 },
+    { type: 'fire_hydrant', x: 1600 },
+    { type: 'fire_hydrant', x: 2800 },
+    { type: 'fire_hydrant', x: 4100 },
+    { type: 'streetlamp', x: 400 },
+    { type: 'streetlamp', x: 800 },
+    { type: 'streetlamp', x: 1400 },
+    { type: 'streetlamp', x: 1900 },
+    { type: 'streetlamp', x: 2500 },
+    { type: 'streetlamp', x: 3100 },
+    { type: 'streetlamp', x: 3700 },
+    { type: 'streetlamp', x: 4300 },
+    { type: 'pizza_shop', x: 1000 },
+    { type: 'central_park', x: 2200 },
+    { type: 'statue_liberty', x: 4550 },
+    { type: 'subway', x: 1700 },
+    { type: 'pigeon_flock', x: 500 },
+    { type: 'pigeon_flock', x: 2600 },
+    { type: 'pigeon_flock', x: 3800 },
+  ],
+};
+
+// Init level 2 yarn balls on higher platforms
+for (const p of level2.platforms) {
+  if (p.y < 290) {
+    level2.yarnBalls.push({
+      x: p.x + p.w / 2,
+      y: p.y - 14,
+      color: yarnColors[level2.yarnBalls.length % yarnColors.length],
+      collected: false,
+      bobPhase: Math.random() * Math.PI * 2
+    });
+  }
+}
+
+// Level 2 NPCs
+const nycNpcs = [];
+const nycNpcColors = ['#fca5a5','#93c5fd','#d8b4fe','#fde68a'];
+const nycNpcAccessories = ['glasses','scarf','bow','flower'];
+for (let i = 0; i < 4; i++) {
+  nycNpcs.push({
+    x: 400 + i * 900 + Math.random() * 200,
+    y: GROUND_Y,
+    color: nycNpcColors[i],
+    accessory: nycNpcAccessories[i],
+    vx: (Math.random() - 0.5) * 1.5,
+    walkFrame: 0, walkTimer: 0,
+    facing: 1,
+    idleTimer: Math.random() * 200
+  });
+}
+
+function switchToLevel(lvl) {
+  levelTransition.active = true;
+  levelTransition.timer = 0;
+  levelTransition.toLevel = lvl;
+  crossfadeToLevel(lvl);
+}
+
+function completeTransition() {
+  currentLevel = levelTransition.toLevel;
+  levelTransition.active = false;
+  player.x = 100;
+  player.y = GROUND_Y;
+  player.vy = 0;
+  player.onGround = true;
+  popups = [];
+  cooking.active = false;
+  fishing.active = false;
+  insideHouse = false;
+  insidePizza = false;
+  insidePark = false;
+  insideCamper = false;
+  insideWindmill = false;
+  insidePantheon = false;
+  swimming = false;
+  surfing = false;
+  skiing = false;
+  pizzaMaking.stage = 'idle';
+  pizzaMaking.progress = 0;
+}
+
+function getCurrentPlatforms() {
+  return currentLevel === 1 ? platforms : currentLevel === 2 ? level2.platforms : currentLevel === 3 ? level3.platforms : currentLevel === 4 ? level4.platforms : level5.platforms;
+}
+
+function getCurrentYarnBalls() {
+  return currentLevel === 1 ? yarnBalls : currentLevel === 2 ? level2.yarnBalls : currentLevel === 3 ? level3.yarnBalls : currentLevel === 4 ? level4.yarnBalls : level5.yarnBalls;
+}
+
+function getCurrentWorldW() {
+  return currentLevel === 1 ? WORLD_W : currentLevel === 2 ? level2.worldW : currentLevel === 3 ? level3.worldW : currentLevel === 4 ? level4.worldW : level5.worldW;
+}
+
+// ── Level 3: Rome ──
+const level3 = {
+  worldW: 4800,
+  platforms: [
+    { x: 150, y: 340, w: 90 },
+    { x: 350, y: 280, w: 80 },
+    { x: 550, y: 220, w: 90 },
+    { x: 750, y: 340, w: 100 },
+    { x: 950, y: 270, w: 80 },
+    { x: 1150, y: 210, w: 90 },
+    { x: 1400, y: 330, w: 80 },
+    { x: 1600, y: 260, w: 90 },
+    { x: 1800, y: 340, w: 100 },
+    { x: 2000, y: 280, w: 80 },
+    { x: 2200, y: 220, w: 90 },
+    { x: 2450, y: 340, w: 80 },
+    { x: 2650, y: 270, w: 90 },
+    { x: 2850, y: 210, w: 80 },
+    { x: 3100, y: 330, w: 100 },
+    { x: 3300, y: 260, w: 80 },
+    { x: 3550, y: 340, w: 90 },
+    { x: 3750, y: 280, w: 80 },
+    { x: 3950, y: 220, w: 90 },
+    { x: 4200, y: 340, w: 100 },
+    { x: 4400, y: 270, w: 80 },
+  ],
+  yarnBalls: [],
+  scenes: [
+    { type: 'colosseum', x: 800 },
+    { type: 'fountain', x: 1500 },
+    { type: 'roman_column', x: 400 },
+    { type: 'roman_column', x: 2000 },
+    { type: 'roman_column', x: 3200 },
+    { type: 'roman_column', x: 4000 },
+    { type: 'gelato_cart', x: 1000 },
+    { type: 'gelato_cart', x: 2800 },
+    { type: 'vespa', x: 600 },
+    { type: 'vespa', x: 1800 },
+    { type: 'vespa', x: 3400 },
+    { type: 'olive_tree', x: 300 },
+    { type: 'olive_tree', x: 1200 },
+    { type: 'olive_tree', x: 2400 },
+    { type: 'olive_tree', x: 3600 },
+    { type: 'olive_tree', x: 4400 },
+    { type: 'pantheon', x: 2600 },
+    { type: 'pasta_shop', x: 3800 },
+    { type: 'leaning_tower', x: 3000 },
+    { type: 'piazza', x: 4200 },
+    { type: 'fiat', x: 4500 },
+  ],
+};
+
+// Init level 3 yarn balls
+for (const p of level3.platforms) {
+  if (p.y < 280) {
+    level3.yarnBalls.push({
+      x: p.x + p.w / 2,
+      y: p.y - 14,
+      color: yarnColors[level3.yarnBalls.length % yarnColors.length],
+      collected: false,
+      bobPhase: Math.random() * Math.PI * 2
+    });
+  }
+}
+
+// Level 3 NPCs
+const romeNpcs = [];
+const romeNpcColors = ['#fca5a5','#bbf7d0','#ddd6fe','#fde68a'];
+const romeNpcAccessories = ['bow','flower','glasses','scarf'];
+for (let i = 0; i < 4; i++) {
+  romeNpcs.push({
+    x: 500 + i * 800 + Math.random() * 200,
+    y: GROUND_Y,
+    color: romeNpcColors[i],
+    accessory: romeNpcAccessories[i],
+    vx: (Math.random() - 0.5) * 1.2,
+    walkFrame: 0, walkTimer: 0,
+    facing: 1,
+    idleTimer: Math.random() * 200
+  });
+}
+
+// ── Level 4: Hawaii ──
+const level4 = {
+  worldW: 5200,
+  platforms: [
+    { x: 200, y: 340, w: 90 },
+    { x: 450, y: 280, w: 80 },
+    { x: 700, y: 220, w: 90 },
+    { x: 950, y: 340, w: 100 },
+    { x: 1200, y: 270, w: 80 },
+    { x: 1450, y: 210, w: 90 },
+    { x: 1700, y: 330, w: 80 },
+    { x: 1950, y: 260, w: 90 },
+    { x: 2200, y: 340, w: 100 },
+    { x: 2450, y: 280, w: 80 },
+    { x: 2700, y: 220, w: 90 },
+    { x: 2950, y: 340, w: 80 },
+    { x: 3200, y: 270, w: 90 },
+    { x: 3450, y: 210, w: 80 },
+    { x: 3700, y: 330, w: 100 },
+    { x: 3950, y: 260, w: 80 },
+    { x: 4200, y: 340, w: 90 },
+    { x: 4450, y: 280, w: 80 },
+    { x: 4700, y: 220, w: 90 },
+    { x: 4950, y: 340, w: 100 },
+  ],
+  yarnBalls: [],
+  scenes: [
+    { type: 'palm_tree', x: 200 },
+    { type: 'palm_tree', x: 800 },
+    { type: 'palm_tree', x: 1600 },
+    { type: 'palm_tree', x: 2400 },
+    { type: 'palm_tree', x: 3200 },
+    { type: 'palm_tree', x: 4000 },
+    { type: 'palm_tree', x: 4800 },
+    { type: 'tiki_torch', x: 600 },
+    { type: 'tiki_torch', x: 1400 },
+    { type: 'tiki_torch', x: 2200 },
+    { type: 'tiki_torch', x: 3000 },
+    { type: 'tiki_torch', x: 3800 },
+    { type: 'coconut_pile', x: 400 },
+    { type: 'coconut_pile', x: 1200 },
+    { type: 'coconut_pile', x: 2000 },
+    { type: 'coconut_pile', x: 2800 },
+    { type: 'coconut_pile', x: 3600 },
+    { type: 'coconut_pile', x: 4400 },
+    { type: 'volcano', x: 4600 },
+    { type: 'beach_hut', x: 1000 },
+    { type: 'beach_hut', x: 3400 },
+    { type: 'surfboard', x: 1800 },
+    { type: 'sea_turtle', x: 500 },
+    { type: 'sea_turtle', x: 2600 },
+    { type: 'sea_turtle', x: 4200 },
+    { type: 'flower_lei', x: 300 },
+    { type: 'flower_lei', x: 1900 },
+    { type: 'flower_lei', x: 3500 },
+    { type: 'airport', x: 4900 },
+  ],
+};
+const AIRPORT_POS = { x: 4900 };
+
+// Init level 4 yarn balls
+for (const p of level4.platforms) {
+  if (p.y < 280) {
+    level4.yarnBalls.push({
+      x: p.x + p.w / 2,
+      y: p.y - 14,
+      color: yarnColors[level4.yarnBalls.length % yarnColors.length],
+      collected: false,
+      bobPhase: Math.random() * Math.PI * 2
+    });
+  }
+}
+
+// Level 4 NPCs
+const hawaiiNpcs = [];
+const hawaiiNpcColors = ['#fda4af','#86efac','#c4b5fd','#fde68a'];
+const hawaiiNpcAccessories = ['flower','bow','glasses','scarf'];
+for (let i = 0; i < 4; i++) {
+  hawaiiNpcs.push({
+    x: 500 + i * 1000 + Math.random() * 200,
+    y: GROUND_Y,
+    color: hawaiiNpcColors[i],
+    accessory: hawaiiNpcAccessories[i],
+    vx: (Math.random() - 0.5) * 1.2,
+    walkFrame: 0, walkTimer: 0,
+    facing: 1,
+    idleTimer: Math.random() * 200
+  });
+}
+
+// ── Level 5: Alps ──
+// The Alps is a downhill skiing level — the kitty starts at the top-left
+// and skis right/downhill, dodging trees, jumping cornices, collecting diamonds.
+let skiing = false;
+let diamondCount = 0;
+let alpsScrollX = 0;
+const ALPS_WORLD_W = 6000;
+const ALPS_SPEED = 3.5; // auto-scroll speed while skiing
+
+const level5 = {
+  worldW: ALPS_WORLD_W,
+  // Cornices (big snow ledges to jump off)
+  cornices: [
+    { x: 800, y: 340, w: 120 },
+    { x: 1600, y: 300, w: 140 },
+    { x: 2500, y: 320, w: 130 },
+    { x: 3400, y: 280, w: 150 },
+    { x: 4300, y: 310, w: 120 },
+    { x: 5000, y: 290, w: 140 },
+  ],
+  // Trees to dodge (x positions)
+  trees: [],
+  // Diamonds to collect
+  diamonds: [],
+};
+
+// Generate trees along the slope
+for (let tx = 300; tx < ALPS_WORLD_W - 200; tx += 140 + Math.random() * 120) {
+  // Don't place trees on cornices
+  let onCornice = false;
+  for (const c of level5.cornices) {
+    if (tx > c.x - 20 && tx < c.x + c.w + 20) { onCornice = true; break; }
+  }
+  if (!onCornice) {
+    level5.trees.push({
+      x: tx,
+      y: GROUND_Y,
+      size: 0.7 + Math.random() * 0.6,
+      hit: false
+    });
+  }
+}
+
+// Generate diamonds along the run — many on cornices, some in the air
+for (const c of level5.cornices) {
+  // Row of diamonds above each cornice
+  for (let i = 0; i < 3; i++) {
+    level5.diamonds.push({
+      x: c.x + 20 + i * (c.w - 40) / 2,
+      y: c.y - 30 - i * 10,
+      collected: false,
+      bobPhase: Math.random() * Math.PI * 2
+    });
+  }
+}
+// Some diamonds between cornices
+for (let dx = 400; dx < ALPS_WORLD_W - 300; dx += 250 + Math.random() * 200) {
+  let onCornice = false;
+  for (const c of level5.cornices) {
+    if (dx > c.x - 40 && dx < c.x + c.w + 40) { onCornice = true; break; }
+  }
+  if (!onCornice) {
+    level5.diamonds.push({
+      x: dx,
+      y: GROUND_Y - 40 - Math.random() * 30,
+      collected: false,
+      bobPhase: Math.random() * Math.PI * 2
+    });
+  }
+}
+
+// Use cornices as platforms for the Alps
+level5.platforms = level5.cornices.map(c => ({ x: c.x, y: c.y, w: c.w }));
+level5.yarnBalls = []; // No yarn balls — diamonds instead
+
+// Level 5 NPCs (ski-themed kitties standing around)
+const alpsNpcs = [];
+const alpsNpcColors = ['#bae6fd','#fda4af','#d9f99d','#e9d5ff'];
+const alpsNpcAccessories = ['scarf','bow','glasses','flower'];
+for (let i = 0; i < 4; i++) {
+  alpsNpcs.push({
+    x: 500 + i * 1200 + Math.random() * 200,
+    y: GROUND_Y,
+    color: alpsNpcColors[i],
+    accessory: alpsNpcAccessories[i],
+    vx: (Math.random() - 0.5) * 0.8,
+    walkFrame: 0, walkTimer: 0,
+    facing: 1,
+    idleTimer: Math.random() * 200
+  });
+}
+
+// ── Canvas Setup ──
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+function resize() {
+  canvas.width = Math.min(window.innerWidth - 20, 960);
+  canvas.height = Math.min(window.innerHeight - 20, 540);
+}
+resize();
+window.addEventListener('resize', resize);
+
+// ── Input ──
+window.addEventListener('keydown', e => {
+  keys[e.code] = true;
+  if (e.code === 'Space') e.preventDefault();
+});
+window.addEventListener('keyup', e => { keys[e.code] = false; });
+
+// ── Start ──
+document.getElementById('startBtn').addEventListener('click', startGame);
+document.getElementById('nameInput').addEventListener('keydown', e => {
+  if (e.key === 'Enter') startGame();
+});
+
+function startGame() {
+  const name = document.getElementById('nameInput').value.trim();
+  playerName = name || 'Sparkle';
+  document.getElementById('startScreen').style.display = 'none';
+  document.getElementById('hud').style.display = 'flex';
+  document.getElementById('controls').style.display = 'flex';
+  document.getElementById('hudName').textContent = playerName;
+  initMeows();
+  // Start music (requires user gesture, which the click/enter provides)
+  startLevelMusic(1);
+  requestAnimationFrame(loop);
+}
+
+// ── Game Loop ──
+let lastTime = 0;
+function loop(ts) {
+  const dt = Math.min(ts - (lastTime || ts), 33);
+  lastTime = ts;
+  gameTime += dt;
+
+  update(dt);
+  draw();
+  requestAnimationFrame(loop);
+}
+
+// ── Update ──
+function update(dt) {
+  updateMusicFade(dt);
+
+  // Level transition animation
+  if (levelTransition.active) {
+    levelTransition.timer += dt;
+    if (levelTransition.timer > 1500) {
+      completeTransition();
+    }
+    return;
+  }
+
+  if (insideHouse) {
+    if (keys['Enter']) {
+      keys['Enter'] = false;
+      insideHouse = false;
+    }
+    return;
+  }
+
+  if (insidePizza) {
+    updatePizzaMinigame(dt);
+    if (keys['Enter'] && pizzaMaking.stage === 'idle') {
+      keys['Enter'] = false;
+      insidePizza = false;
+    }
+    return;
+  }
+
+  if (insideCamper) {
+    if (keys['Enter']) {
+      keys['Enter'] = false;
+      insideCamper = false;
+    }
+    return;
+  }
+  if (insideWindmill) {
+    if (keys['Enter']) {
+      keys['Enter'] = false;
+      insideWindmill = false;
+    }
+    return;
+  }
+  if (insidePark) {
+    if (keys['Enter']) { keys['Enter'] = false; insidePark = false; }
+    return;
+  }
+
+  if (insidePantheon) {
+    if (keys['Enter']) { keys['Enter'] = false; insidePantheon = false; }
+    return;
+  }
+
+  if (swimming) {
+    if (keys['KeyS']) { keys['KeyS'] = false; swimming = false; }
+    return;
+  }
+
+  if (surfing) {
+    if (keys['KeyS']) { keys['KeyS'] = false; surfing = false; }
+    return;
+  }
+
+  // Movement
+  player.vx = 0;
+  if (keys['ArrowLeft']) { player.vx = -MOVE_SPEED; player.facing = -1; }
+  if (keys['ArrowRight']) { player.vx = MOVE_SPEED; player.facing = 1; }
+  if (keys['ArrowUp']) { player.vx += 0; } // up on land is no-op for now
+  if (keys['ArrowDown']) { player.vx += 0; }
+
+  // Jump
+  if (keys['Space'] && player.onGround) {
+    player.vy = JUMP_VEL;
+    player.onGround = false;
+    playMeow();
+  }
+
+  // Physics
+  player.vy += GRAVITY;
+  player.x += player.vx;
+  player.y += player.vy;
+
+  // Platform collision (only when falling)
+  let onPlatform = false;
+  if (player.vy >= 0) {
+    for (const p of getCurrentPlatforms()) {
+      if (player.x > p.x - 10 && player.x < p.x + p.w + 10 &&
+          player.y >= p.y && player.y - player.vy <= p.y) {
+        player.y = p.y;
+        player.vy = 0;
+        player.onGround = true;
+        onPlatform = true;
+        break;
+      }
+    }
+  }
+
+  // Ground collision (only if not on a platform)
+  if (!onPlatform) {
+    const groundLevel = getGroundLevel(player.x);
+    if (player.y >= groundLevel) {
+      player.y = groundLevel;
+      player.vy = 0;
+      player.onGround = true;
+    }
+  }
+
+  // Yarn ball collection
+  for (const yb of getCurrentYarnBalls()) {
+    if (yb.collected) continue;
+    const dx = player.x - yb.x;
+    const dy = (player.y - 20) - yb.y;
+    if (dx * dx + dy * dy < 625) { // ~25px radius
+      yb.collected = true;
+      yarnCount++;
+      score += 20;
+      addPopup(yb.x, yb.y - 20, '+20 Yarn!', yb.color);
+      playChaChing();
+    }
+  }
+
+  // World bounds
+  player.x = Math.max(20, Math.min(getCurrentWorldW() - 20, player.x));
+
+  // Walk animation
+  if (Math.abs(player.vx) > 0) {
+    player.walkTimer += dt;
+    if (player.walkTimer > 120) {
+      player.walkTimer = 0;
+      player.walkFrame = (player.walkFrame + 1) % 4;
+    }
+  } else {
+    player.walkFrame = 0;
+  }
+
+  // Fishing (level 1 only)
+  const inPond = currentLevel === 1 && player.x > POND.x && player.x < POND.x + POND.w;
+  if (keys['KeyF'] && inPond && !fishing.active && !cooking.active) {
+    keys['KeyF'] = false;
+    fishing.active = true;
+    fishing.timer = 0;
+    fishing.caught = false;
+  }
+  if (fishing.active) {
+    fishing.timer += dt;
+    if (fishing.timer > 1500 + Math.random() * 500) {
+      fishing.active = false;
+      fishing.caught = true;
+      fishCount++;
+      score += 10;
+      addPopup(player.x, player.y - 40, '+10 Fish!', '#38bdf8');
+      playChaChing();
+      // respawn a fish
+      if (pondFish.length < 8) {
+        const colors = ['#fb923c','#38bdf8','#4ade80','#f472b6'];
+        pondFish.push({
+          x: POND.x + 40 + Math.random() * (POND.w - 80),
+          y: GROUND_Y + 10 + Math.random() * (POND.depth - 30),
+          vx: (Math.random() - 0.5) * 1.5,
+          color: colors[Math.floor(Math.random() * 4)],
+          size: 14 + Math.random() * 8,
+          wobble: Math.random() * Math.PI * 2
+        });
+      }
+    }
+  }
+
+  // Cooking (level 1 only)
+  const nearGrill = currentLevel === 1 && Math.abs(player.x - GRILL.x) < 60;
+  if (keys['KeyC'] && nearGrill && !cooking.active && !fishing.active) {
+    keys['KeyC'] = false;
+    cooking.active = true;
+    cooking.progress = 0;
+    cooking.burnt = false;
+  }
+  if (cooking.active) {
+    cooking.progress += dt;
+    if (cooking.progress > 3000 && cooking.progress < 5000) {
+      // perfectly cooked window — auto collect
+      cooking.active = false;
+      baconCount++;
+      score += 15;
+      addPopup(GRILL.x, GROUND_Y - 60, '+15 Bacon!', '#fb923c');
+      playChaChing();
+    } else if (cooking.progress >= 5000) {
+      cooking.active = false;
+      cooking.burnt = true;
+      addPopup(GRILL.x, GROUND_Y - 60, 'Burnt!', '#ef4444');
+    }
+  }
+
+  // House entry (level 1 only)
+  const nearHouse = currentLevel === 1 && player.x > HOUSE.x - 20 && player.x < HOUSE.x + HOUSE.w + 20;
+  if (keys['Enter'] && nearHouse && !insideHouse) {
+    keys['Enter'] = false;
+    insideHouse = true;
+  }
+
+  // Camper entry (level 1 only)
+  let nearCamper = false;
+  if (currentLevel === 1) {
+    for (const s of bgScenes) {
+      if (s.type === 'rv' && Math.abs(player.x - s.x) < 45) {
+        nearCamper = true;
+        if (keys['Enter'] && !insideCamper) {
+          keys['Enter'] = false;
+          insideCamper = true;
+        }
+        break;
+      }
+    }
+  }
+
+  // Windmill entry (level 1 only)
+  let nearWindmill = false;
+  if (currentLevel === 1) {
+    for (const s of bgScenes) {
+      if (s.type === 'windmill' && Math.abs(player.x - s.x) < 30) {
+        nearWindmill = true;
+        if (keys['Enter'] && !insideWindmill) {
+          keys['Enter'] = false;
+          insideWindmill = true;
+        }
+        break;
+      }
+    }
+  }
+
+  // Honey collection (level 1 only — H key near beehive)
+  let nearBeehive = false;
+  if (currentLevel === 1) {
+    for (const s of bgScenes) {
+      if (s.type === 'beehive' && Math.abs(player.x - s.x) < 40) {
+        nearBeehive = true;
+        if (keys['KeyH']) {
+          keys['KeyH'] = false;
+          honeyCount++;
+          score += 12;
+          addPopup(s.x, GROUND_Y - 80, '+12 Honey!', '#f59e0b');
+          playChaChing();
+        }
+        break;
+      }
+    }
+  }
+
+  // Pizza shop entry (level 2 only)
+  const nearPizza = currentLevel === 2 && Math.abs(player.x - PIZZA_SHOP.x) < 50;
+  if (keys['Enter'] && nearPizza && !insidePizza) {
+    keys['Enter'] = false;
+    insidePizza = true;
+    pizzaMaking.stage = 'idle';
+    pizzaMaking.progress = 0;
+    pizzaMaking.active = false;
+  }
+
+  // Hot dog stands (level 2 — buy for 10 points)
+  let nearHotdog = false;
+  if (currentLevel === 2) {
+    for (const hx of HOTDOG_POSITIONS) {
+      if (Math.abs(player.x - hx) < 40) {
+        nearHotdog = true;
+        if (keys['KeyC'] && score >= 10) {
+          keys['KeyC'] = false;
+          score -= 10;
+          hotdogCount++;
+          addPopup(player.x, player.y - 40, 'Hot Dog! -10pts', '#fbbf24');
+        }
+        break;
+      }
+    }
+  }
+
+  // Central Park entry (level 2)
+  const nearPark = currentLevel === 2 &&
+    player.x > CENTRAL_PARK_POS.x - 80 && player.x < CENTRAL_PARK_POS.x + 80;
+  if (keys['Enter'] && nearPark && !insidePark && !insidePizza) {
+    keys['Enter'] = false;
+    insidePark = true;
+  }
+
+  // Taxi → Rome (level 2)
+  let nearTaxi = false;
+  if (currentLevel === 2) {
+    for (const tx of TAXI_POSITIONS) {
+      if (Math.abs(player.x - tx) < 40) {
+        nearTaxi = true;
+        if (keys['Enter'] && !insidePizza && !insidePark) {
+          keys['Enter'] = false;
+          switchToLevel(3);
+        }
+        break;
+      }
+    }
+  }
+
+  // Rome interactions (level 3)
+  let nearFountain = false;
+  let nearGelato = false;
+  let nearPantheonDoor = false;
+  let nearFiat = false;
+  if (currentLevel === 3) {
+    // Fountain swimming
+    if (Math.abs(player.x - FOUNTAIN_POS.x) < 45) {
+      nearFountain = true;
+      if (keys['KeyS']) {
+        keys['KeyS'] = false;
+        swimming = true;
+      }
+    }
+    // Gelato
+    for (const gx of GELATO_POSITIONS) {
+      if (Math.abs(player.x - gx) < 40) {
+        nearGelato = true;
+        if (keys['KeyG']) {
+          keys['KeyG'] = false;
+          gelatoCount++;
+          score += 5;
+          addPopup(player.x, player.y - 40, '+5 Gelato!', '#fda4af');
+          playChaChing();
+        }
+        break;
+      }
+    }
+    // Pantheon
+    if (Math.abs(player.x - PANTHEON_POS.x) < 55) {
+      nearPantheonDoor = true;
+      if (keys['Enter']) {
+        keys['Enter'] = false;
+        insidePantheon = true;
+      }
+    }
+    // Fiat → Hawaii
+    if (Math.abs(player.x - FIAT_POS.x) < 45) {
+      nearFiat = true;
+      if (keys['Enter'] && !insidePantheon) {
+        keys['Enter'] = false;
+        switchToLevel(4);
+      }
+    }
+  }
+
+  // Hawaii interactions (level 4)
+  let nearTiki = false;
+  let nearCoconut = false;
+  let nearSurf = false;
+  let nearAirport = false;
+  if (currentLevel === 4) {
+    // Tiki torches
+    for (const tx of TIKI_POSITIONS) {
+      if (Math.abs(player.x - tx) < 40) {
+        nearTiki = true;
+        if (keys['KeyT']) {
+          keys['KeyT'] = false;
+          tikiCount++;
+          score += 15;
+          addPopup(player.x, player.y - 40, '+15 Tiki!', '#f97316');
+          playChaChing();
+        }
+        break;
+      }
+    }
+    // Coconuts
+    for (const cx2 of COCONUT_POSITIONS) {
+      if (Math.abs(player.x - cx2) < 40) {
+        nearCoconut = true;
+        if (keys['KeyC']) {
+          keys['KeyC'] = false;
+          coconutCount++;
+          score += 10;
+          addPopup(player.x, player.y - 40, '+10 Coconut!', '#92400e');
+          playChaChing();
+        }
+        break;
+      }
+    }
+    // Surfing
+    if (Math.abs(player.x - SURF_POS.x) < 45) {
+      nearSurf = true;
+      if (keys['KeyS']) {
+        keys['KeyS'] = false;
+        surfing = true;
+      }
+    }
+    // Airport → Alps
+    if (Math.abs(player.x - AIRPORT_POS.x) < 55) {
+      nearAirport = true;
+      if (keys['Enter']) {
+        keys['Enter'] = false;
+        switchToLevel(5);
+      }
+    }
+  }
+
+  // Alps interactions (level 5)
+  let nearChalet = false;
+  if (currentLevel === 5) {
+    // Auto-ski: push player right continuously
+    player.vx = Math.max(player.vx, ALPS_SPEED);
+
+    // Diamond collection
+    for (const d of level5.diamonds) {
+      if (d.collected) continue;
+      const ddx = player.x - d.x;
+      const ddy = (player.y - 20) - d.y;
+      if (ddx * ddx + ddy * ddy < 625) {
+        d.collected = true;
+        diamondCount++;
+        score += 25;
+        addPopup(d.x, d.y - 20, '+25 Diamond!', '#60a5fa');
+        playChaChing();
+      }
+    }
+
+    // Tree collision (slow down + lose points)
+    for (const tree of level5.trees) {
+      if (tree.hit) continue;
+      if (Math.abs(player.x - tree.x) < 12 && player.y > tree.y - 50 * tree.size) {
+        tree.hit = true;
+        score = Math.max(0, score - 10);
+        addPopup(tree.x, player.y - 40, '-10 Ouch!', '#ef4444');
+        player.vx = 1; // slow down on hit
+      }
+    }
+
+    // Reset trees that are far behind (so they can hit again on replay)
+    for (const tree of level5.trees) {
+      if (tree.hit && player.x - tree.x > 300) tree.hit = false;
+    }
+
+    // End of run — reach the chalet at the bottom
+    if (player.x > ALPS_WORLD_W - 200) {
+      nearChalet = true;
+      player.vx = 0; // stop at the end
+    }
+  }
+
+  // Rainbow bridge portal (level 1 → level 2)
+  if (currentLevel === 1) {
+    const dx = player.x - BRIDGE_PORTAL.x;
+    const dy = player.y - GROUND_Y;
+    if (dx * dx + dy * dy < BRIDGE_PORTAL.radius * BRIDGE_PORTAL.radius && keys['Enter']) {
+      keys['Enter'] = false;
+      switchToLevel(2);
+    }
+  }
+
+  // Pond fish AI (level 1 only)
+  if (currentLevel === 1) {
+    for (const f of pondFish) {
+      f.wobble += 0.03;
+      f.x += f.vx;
+      f.y += Math.sin(f.wobble) * 0.3;
+      if (f.x < POND.x + 20 || f.x > POND.x + POND.w - 20) f.vx *= -1;
+      f.y = Math.max(GROUND_Y + 5, Math.min(GROUND_Y + POND.depth - 10, f.y));
+    }
+  }
+
+  // NPC AI
+  const activeNpcs = currentLevel === 1 ? npcs : currentLevel === 2 ? nycNpcs : currentLevel === 3 ? romeNpcs : currentLevel === 4 ? hawaiiNpcs : alpsNpcs;
+  const worldW = getCurrentWorldW();
+  for (const npc of activeNpcs) {
+    npc.idleTimer -= dt / 16;
+    if (npc.idleTimer <= 0) {
+      npc.vx = (Math.random() - 0.5) * 2;
+      npc.idleTimer = 100 + Math.random() * 200;
+    }
+    npc.x += npc.vx * 0.5;
+    npc.x = Math.max(40, Math.min(worldW - 40, npc.x));
+    npc.facing = npc.vx >= 0 ? 1 : -1;
+    if (Math.abs(npc.vx) > 0.1) {
+      npc.walkTimer += dt;
+      if (npc.walkTimer > 150) { npc.walkTimer = 0; npc.walkFrame = (npc.walkFrame + 1) % 4; }
+    } else {
+      npc.walkFrame = 0;
+    }
+  }
+
+  // Popups
+  for (let i = popups.length - 1; i >= 0; i--) {
+    popups[i].y -= 1;
+    popups[i].life -= dt;
+    if (popups[i].life <= 0) popups.splice(i, 1);
+  }
+
+  // HUD update
+  document.getElementById('hudScore').textContent = score;
+  document.getElementById('hudFish').textContent = fishCount;
+  document.getElementById('hudBacon').textContent = baconCount;
+  document.getElementById('hudYarn').textContent = yarnCount;
+  document.getElementById('hudLevel').textContent = currentLevel === 1 ? 'Meadow' : currentLevel === 2 ? 'NYC' : currentLevel === 3 ? 'Rome' : currentLevel === 4 ? 'Hawaii' : 'Alps';
+  document.getElementById('hudPizza').textContent = pizzaMaking.pizzaCount;
+  document.getElementById('hudHotdog').textContent = hotdogCount;
+  document.getElementById('hudGelato').textContent = gelatoCount;
+  document.getElementById('hudHoney').textContent = honeyCount;
+  document.getElementById('hudTiki').textContent = tikiCount;
+  document.getElementById('hudCoconut').textContent = coconutCount;
+  document.getElementById('hudDiamond').textContent = diamondCount;
+
+  // Prompt
+  updatePrompt(inPond, nearGrill, nearHouse, nearCamper, nearWindmill, nearBeehive, nearPizza, nearHotdog, nearPark, nearTaxi, nearFountain, nearGelato, nearPantheonDoor, nearFiat, nearTiki, nearCoconut, nearSurf, nearAirport, nearChalet);
+}
+
+function getGroundLevel(x) {
+  // Pond area is lower (level 1 only)
+  if (currentLevel === 1 && x > POND.x + 20 && x < POND.x + POND.w - 20) {
+    return GROUND_Y + POND.depth;
+  }
+  return GROUND_Y;
+}
+
+function addPopup(x, y, text, color) {
+  popups.push({ x, y, text, color, life: 1500 });
+}
+
+function updatePizzaMinigame(dt) {
+  if (pizzaMaking.stage === 'idle') {
+    if (keys['KeyC']) {
+      keys['KeyC'] = false;
+      pizzaMaking.stage = 'dough';
+      pizzaMaking.progress = 0;
+    }
+  } else if (pizzaMaking.stage === 'dough') {
+    pizzaMaking.progress += dt;
+    if (keys['KeyC'] && pizzaMaking.progress > 800) {
+      keys['KeyC'] = false;
+      pizzaMaking.stage = 'toppings';
+      pizzaMaking.progress = 0;
+    }
+  } else if (pizzaMaking.stage === 'toppings') {
+    pizzaMaking.progress += dt;
+    if (keys['KeyC'] && pizzaMaking.progress > 800) {
+      keys['KeyC'] = false;
+      pizzaMaking.stage = 'oven';
+      pizzaMaking.progress = 0;
+    }
+  } else if (pizzaMaking.stage === 'oven') {
+    pizzaMaking.progress += dt;
+    // Sweet spot: 3000-4500ms = perfect, >4500 = burnt
+    if (keys['KeyC']) {
+      keys['KeyC'] = false;
+      if (pizzaMaking.progress >= 3000 && pizzaMaking.progress < 4500) {
+        // Perfect pizza!
+        pizzaMaking.pizzaCount++;
+        score += 25;
+        addPopup(player.x, player.y - 40, '+25 Perfect Pizza!', '#f97316');
+        playChaChing();
+      } else if (pizzaMaking.progress < 3000) {
+        // Undercooked
+        addPopup(player.x, player.y - 40, 'Undercooked!', '#93c5fd');
+      } else {
+        // Burnt
+        addPopup(player.x, player.y - 40, 'Burnt pizza!', '#ef4444');
+      }
+      pizzaMaking.stage = 'idle';
+      pizzaMaking.progress = 0;
+    }
+    if (pizzaMaking.progress >= 6000) {
+      // Auto-burn
+      addPopup(player.x, player.y - 40, 'Burnt to a crisp!', '#ef4444');
+      pizzaMaking.stage = 'idle';
+      pizzaMaking.progress = 0;
+    }
+  }
+  // HUD updates still needed
+  document.getElementById('hudScore').textContent = score;
+  document.getElementById('hudPizza').textContent = pizzaMaking.pizzaCount;
+}
+
+function updatePrompt(inPond, nearGrill, nearHouse, nearCamper, nearWindmill, nearBeehive, nearPizza, nearHotdog, nearPark, nearTaxi, nearFountain, nearGelato, nearPantheonDoor, nearFiat, nearTiki, nearCoconut, nearSurf, nearAirport, nearChalet) {
+  const el = document.getElementById('prompt');
+  if (surfing) {
+    el.textContent = 'Surfing the waves! Press S to get off';
+    el.style.display = 'block';
+    return;
+  }
+  if (swimming) {
+    el.textContent = 'Splashing in the fountain! Press S to get out';
+    el.style.display = 'block';
+    return;
+  }
+  if (insidePantheon) {
+    el.textContent = 'Inside the Pantheon... Press Enter to leave';
+    el.style.display = 'block';
+    return;
+  }
+  if (insideCamper) {
+    el.textContent = 'Chilling in the camper... Press Enter to go outside';
+    el.style.display = 'block';
+    return;
+  }
+  if (insideWindmill) {
+    el.textContent = 'Inside the windmill... Press Enter to go outside';
+    el.style.display = 'block';
+    return;
+  }
+  if (insidePark) {
+    el.textContent = 'Relaxing in Central Park... Press Enter to leave';
+    el.style.display = 'block';
+    return;
+  }
+  if (insidePizza) {
+    if (pizzaMaking.stage === 'idle') {
+      el.textContent = 'Press C to make pizza! (Enter to leave)';
+    } else if (pizzaMaking.stage === 'dough') {
+      el.textContent = 'Kneading dough... Press C when ready!';
+    } else if (pizzaMaking.stage === 'toppings') {
+      el.textContent = 'Adding toppings... Press C to put in oven!';
+    } else if (pizzaMaking.stage === 'oven') {
+      const pct = Math.min(100, (pizzaMaking.progress / 3000) * 100);
+      el.textContent = `Baking... ${Math.round(pct)}% — Press C to take out!`;
+    }
+    el.style.display = 'block';
+  } else if (fishing.active) {
+    el.textContent = 'Fishing...';
+    el.style.display = 'block';
+  } else if (cooking.active) {
+    const pct = Math.min(100, (cooking.progress / 3000) * 100);
+    el.textContent = `Cooking... ${Math.round(pct)}%`;
+    el.style.display = 'block';
+  } else if (inPond && !fishing.active) {
+    el.textContent = 'Press F to fish';
+    el.style.display = 'block';
+  } else if (nearGrill && !cooking.active) {
+    el.textContent = 'Press C to cook bacon';
+    el.style.display = 'block';
+  } else if (nearHouse) {
+    el.textContent = 'Press Enter to go inside';
+    el.style.display = 'block';
+  } else if (nearCamper) {
+    el.textContent = 'Press Enter to enter the camper';
+    el.style.display = 'block';
+  } else if (nearWindmill) {
+    el.textContent = 'Press Enter to enter the windmill';
+    el.style.display = 'block';
+  } else if (nearBeehive) {
+    el.textContent = 'Press H to collect honey';
+    el.style.display = 'block';
+  } else if (nearPizza) {
+    el.textContent = 'Press Enter to make pizza!';
+    el.style.display = 'block';
+  } else if (nearHotdog) {
+    el.textContent = score >= 10 ? 'Press C to buy a hot dog (-10 pts)' : 'Not enough points for a hot dog!';
+    el.style.display = 'block';
+  } else if (nearPark) {
+    el.textContent = 'Press Enter to visit Central Park';
+    el.style.display = 'block';
+  } else if (nearTaxi) {
+    el.textContent = 'Press Enter to take a taxi to Rome!';
+    el.style.display = 'block';
+  } else if (nearFountain) {
+    el.textContent = 'Press S to go swimming!';
+    el.style.display = 'block';
+  } else if (nearGelato) {
+    el.textContent = 'Press G for gelato! (+5 pts)';
+    el.style.display = 'block';
+  } else if (nearPantheonDoor) {
+    el.textContent = 'Press Enter to enter the Pantheon';
+    el.style.display = 'block';
+  } else if (nearFiat) {
+    el.textContent = 'Press Enter to take a Fiat to Hawaii!';
+    el.style.display = 'block';
+  } else if (nearTiki) {
+    el.textContent = 'Press T to light tiki torch! (+15 pts)';
+    el.style.display = 'block';
+  } else if (nearCoconut) {
+    el.textContent = 'Press C to collect coconut! (+10 pts)';
+    el.style.display = 'block';
+  } else if (nearSurf) {
+    el.textContent = 'Press S to go surfing!';
+    el.style.display = 'block';
+  } else if (nearAirport) {
+    el.textContent = 'Press Enter to fly to the Alps!';
+    el.style.display = 'block';
+  } else if (nearChalet) {
+    el.textContent = 'You made it to the chalet! Great run!';
+    el.style.display = 'block';
+  } else if (currentLevel === 5) {
+    el.textContent = 'Ski downhill! Dodge trees, jump cornices, collect diamonds!';
+    el.style.display = 'block';
+  } else if (currentLevel === 1 && Math.abs(player.x - BRIDGE_PORTAL.x) < 60) {
+    el.textContent = 'Press Enter to travel to NYC!';
+    el.style.display = 'block';
+  } else {
+    el.style.display = 'none';
+  }
+}
+
+// ── Draw ──
+function draw() {
+  const W = canvas.width, H = canvas.height;
+  const ww = getCurrentWorldW();
+  const cam = Math.max(0, Math.min(ww - W, player.x - W / 2));
+
+  // Level transition effect
+  if (levelTransition.active) {
+    drawLevelTransition(W, H);
+    return;
+  }
+
+  // Day/night cycle (0..1, 0=noon, 0.5=midnight)
+  const cycle = (Math.sin(gameTime / DAY_LENGTH * Math.PI * 2 - Math.PI / 2) + 1) / 2;
+  const isNight = cycle > 0.5;
+
+  if (currentLevel === 1) {
+    drawLevel1Sky(W, H, cycle, isNight, cam);
+  } else if (currentLevel === 2) {
+    drawLevel2Sky(W, H, cycle, isNight);
+  } else if (currentLevel === 3) {
+    drawRomeSky(W, H, cycle, isNight);
+  } else if (currentLevel === 4) {
+    drawHawaiiSky(W, H, cycle, isNight);
+  } else {
+    drawAlpsSky(W, H, cycle, isNight);
+  }
+
+  ctx.save();
+  ctx.translate(-cam, 0);
+
+  if (insideHouse) {
+    drawHouseInterior(cam, W, H);
+  } else if (insideCamper) {
+    drawCamperInterior(cam, W, H);
+  } else if (insideWindmill) {
+    drawWindmillInterior(cam, W, H);
+  } else if (insidePizza) {
+    drawPizzaInterior(cam, W, H);
+  } else if (insidePark) {
+    drawParkInterior(cam, W, H);
+  } else if (insidePantheon) {
+    drawPantheonInterior(cam, W, H);
+  } else if (swimming) {
+    drawSwimmingScene(cam, W, H);
+  } else if (surfing) {
+    drawSurfingScene(cam, W, H);
+  } else if (currentLevel === 1) {
+    drawLevel1World(W, H, cam, cycle, isNight);
+  } else if (currentLevel === 2) {
+    drawLevel2World(W, H, cam, cycle, isNight);
+  } else if (currentLevel === 3) {
+    drawRomeWorld(W, H, cam, cycle, isNight);
+  } else if (currentLevel === 4) {
+    drawHawaiiWorld(W, H, cam, cycle, isNight);
+  } else {
+    drawAlpsWorld(W, H, cam, cycle, isNight);
+  }
+
+  ctx.restore();
+}
+
+function drawLevel1Sky(W, H, cycle, isNight, cam) {
+  const dayTop = [135, 206, 250];
+  const nightTop = [15, 23, 42];
+  const dayBot = [255, 253, 240];
+  const nightBot = [30, 41, 82];
+  const t = cycle;
+  const skyTop = lerpColor(dayTop, nightTop, t);
+  const skyBot = lerpColor(dayBot, nightBot, t);
+  const grad = ctx.createLinearGradient(0, 0, 0, H);
+  grad.addColorStop(0, `rgb(${skyTop})`);
+  grad.addColorStop(1, `rgb(${skyBot})`);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, W, H);
+  if (isNight) drawStars(W, H, cycle);
+  if (isNight) drawRainbow(W, H, 0);
+  drawCelestial(W, H, cycle);
+  drawHills(W, H, 0);
+}
+
+function drawLevel2Sky(W, H, cycle, isNight) {
+  // NYC has a more urban sky — deeper blues/grays
+  const dayTop = [120, 160, 200];
+  const nightTop = [10, 15, 30];
+  const dayBot = [200, 210, 220];
+  const nightBot = [25, 30, 50];
+  const t = cycle;
+  const skyTop = lerpColor(dayTop, nightTop, t);
+  const skyBot = lerpColor(dayBot, nightBot, t);
+  const grad = ctx.createLinearGradient(0, 0, 0, H);
+  grad.addColorStop(0, `rgb(${skyTop})`);
+  grad.addColorStop(1, `rgb(${skyBot})`);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, W, H);
+  if (isNight) drawStars(W, H, cycle);
+  drawCelestial(W, H, cycle);
+}
+
+function drawLevel1World(W, H, cam) {
+  drawGround(W, H, cam);
+  drawBgScenes(cam, W);
+  drawPond();
+  for (const f of pondFish) drawFish(f);
+  drawGrill();
+  drawPlatforms();
+  drawYarnBalls();
+  drawHouse();
+  for (const npc of npcs) drawKitty(npc.x, npc.y, npc.color, npc.facing, npc.walkFrame, npc.accessory);
+  drawPlayerAndUI();
+}
+
+function drawLevel2World(W, H, cam) {
+  // Sidewalk/road
+  ctx.fillStyle = '#4b5563';
+  ctx.fillRect(0, GROUND_Y, getCurrentWorldW(), H);
+  ctx.fillStyle = '#6b7280';
+  ctx.fillRect(0, GROUND_Y, getCurrentWorldW(), 4);
+  // Road markings
+  ctx.fillStyle = '#fbbf24';
+  for (let rx = 0; rx < getCurrentWorldW(); rx += 80) {
+    ctx.fillRect(rx, GROUND_Y + 20, 40, 3);
+  }
+  // Sidewalk
+  ctx.fillStyle = '#9ca3af';
+  ctx.fillRect(0, GROUND_Y - 2, getCurrentWorldW(), 6);
+
+  // Background buildings (behind everything)
+  drawNYCBuildings(cam, W);
+
+  // NYC scenes
+  drawNYCScenes(cam, W);
+
+  // Platforms (fire escapes)
+  drawNYCPlatforms();
+
+  // Yarn balls
+  drawNYCYarnBalls();
+
+  // NPCs
+  for (const npc of nycNpcs) drawKitty(npc.x, npc.y, npc.color, npc.facing, npc.walkFrame, npc.accessory);
+
+  drawPlayerAndUI();
+}
+
+function drawPlayerAndUI() {
+  drawKitty(player.x, player.y, player.color, player.facing, player.walkFrame, 'horn');
+
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 12px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText(playerName, player.x, player.y - 38);
+
+  if (fishing.active) {
+    ctx.strokeStyle = '#a3a3a3';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(player.x + player.facing * 10, player.y - 10);
+    ctx.lineTo(player.x + player.facing * 30, player.y + 20);
+    ctx.stroke();
+    ctx.fillStyle = '#ef4444';
+    ctx.beginPath();
+    ctx.arc(player.x + player.facing * 30, player.y + 20, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  for (const p of popups) {
+    const alpha = Math.min(1, p.life / 500);
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = p.color;
+    ctx.font = 'bold 16px system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText(p.text, p.x, p.y);
+    ctx.globalAlpha = 1;
+  }
+}
+
+function drawLevelTransition(W, H) {
+  const t = levelTransition.timer / 1500;
+  // Rainbow wipe effect
+  const colors = ['#ef4444','#f97316','#eab308','#22c55e','#3b82f6','#8b5cf6','#ec4899'];
+  const bandH = H / colors.length;
+  for (let i = 0; i < colors.length; i++) {
+    ctx.fillStyle = colors[i];
+    const delay = i * 0.08;
+    const progress = Math.max(0, Math.min(1, (t - delay) / 0.5));
+    ctx.fillRect(0, i * bandH, W * progress, bandH + 1);
+  }
+  // Level name text
+  if (t > 0.4) {
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 36px system-ui';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const textAlpha = Math.min(1, (t - 0.4) / 0.3);
+    ctx.globalAlpha = textAlpha;
+    const levelNames = { 1: 'Back to the Meadow!', 2: 'Welcome to NYC!', 3: 'Benvenuto a Roma!', 4: 'Aloha Hawaii!', 5: 'Welcome to the Alps!' };
+    const levelSubtitles = { 1: playerName + ' returns home!', 2: playerName + ' arrives in the big city!', 3: playerName + ' explores the Eternal City!', 4: playerName + ' hits the beach!', 5: playerName + ' hits the slopes!' };
+    ctx.fillText(levelNames[levelTransition.toLevel] || 'New Level!', W / 2, H / 2 - 20);
+    ctx.font = '20px system-ui';
+    ctx.fillText(levelSubtitles[levelTransition.toLevel] || '', W / 2, H / 2 + 20);
+    ctx.globalAlpha = 1;
+    ctx.textBaseline = 'alphabetic';
+  }
+}
+
+function drawNYCBuildings(cam, W) {
+  for (const b of level2.buildings) {
+    if (b.x + b.w < cam - 50 || b.x > cam + W + 50) continue;
+    const bx = b.x, by = GROUND_Y;
+
+    // Building body
+    ctx.fillStyle = b.c;
+    ctx.fillRect(bx, by - b.h, b.w, b.h);
+
+    // Spire
+    if (b.spire) {
+      ctx.fillStyle = '#94a3b8';
+      ctx.beginPath();
+      ctx.moveTo(bx + b.w / 2 - 4, by - b.h);
+      ctx.lineTo(bx + b.w / 2, by - b.h - 30);
+      ctx.lineTo(bx + b.w / 2 + 4, by - b.h);
+      ctx.fill();
+    }
+
+    // Windows
+    if (b.windows) {
+      const rows = Math.floor((b.h - 20) / 18);
+      const cols = Math.floor((b.w - 10) / 16);
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+          const wx = bx + 8 + c * 16;
+          const wy = by - b.h + 12 + r * 18;
+          // Some windows lit, some dark
+          const lit = Math.sin((bx + r * 7 + c * 13) * 0.1 + gameTime / 5000) > 0;
+          ctx.fillStyle = lit ? '#fde68a' : 'rgba(0,0,0,0.3)';
+          ctx.fillRect(wx, wy, 8, 10);
+        }
+      }
+    }
+
+    // Roof edge
+    ctx.fillStyle = 'rgba(0,0,0,0.2)';
+    ctx.fillRect(bx - 2, by - b.h - 3, b.w + 4, 5);
+  }
+}
+
+function drawNYCPlatforms() {
+  for (const p of level2.platforms) {
+    // Fire escape style platforms — metallic
+    ctx.fillStyle = 'rgba(0,0,0,0.1)';
+    ctx.fillRect(p.x + 3, p.y + 3, p.w, 12);
+
+    const pGrad = ctx.createLinearGradient(p.x, p.y, p.x, p.y + 12);
+    pGrad.addColorStop(0, '#94a3b8');
+    pGrad.addColorStop(1, '#64748b');
+    ctx.fillStyle = pGrad;
+    ctx.beginPath();
+    ctx.roundRect(p.x, p.y, p.w, 12, 3);
+    ctx.fill();
+
+    // Railing
+    ctx.strokeStyle = '#94a3b8';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(p.x, p.y - 16);
+    ctx.moveTo(p.x + p.w, p.y);
+    ctx.lineTo(p.x + p.w, p.y - 16);
+    ctx.moveTo(p.x, p.y - 16);
+    ctx.lineTo(p.x + p.w, p.y - 16);
+    ctx.stroke();
+  }
+}
+
+function drawNYCYarnBalls() {
+  for (const yb of level2.yarnBalls) {
+    if (yb.collected) continue;
+    const bob = Math.sin(gameTime / 400 + yb.bobPhase) * 3;
+    const yx = yb.x, yy = yb.y + bob;
+
+    ctx.globalAlpha = 0.25;
+    ctx.fillStyle = yb.color;
+    ctx.beginPath();
+    ctx.arc(yx, yy, 18, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+
+    ctx.fillStyle = yb.color;
+    ctx.beginPath();
+    ctx.arc(yx, yy, 12, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = 'rgba(255,255,255,0.4)';
+    ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.arc(yx, yy, 10, 0.3, 1.8); ctx.stroke();
+    ctx.beginPath(); ctx.arc(yx, yy, 8, 2.0, 3.5); ctx.stroke();
+    ctx.beginPath(); ctx.arc(yx, yy, 6, 4.0, 5.5); ctx.stroke();
+
+    ctx.fillStyle = 'rgba(255,255,255,0.6)';
+    ctx.beginPath();
+    ctx.arc(yx - 3, yy - 4, 3, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.strokeStyle = yb.color;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(yx + 10, yy + 5);
+    ctx.quadraticCurveTo(yx + 16, yy + 12 + bob, yx + 12, yy + 18);
+    ctx.stroke();
+  }
+}
+
+function drawNYCScenes(cam, W) {
+  for (const s of level2.scenes) {
+    if (s.x < cam - 200 || s.x > cam + W + 200) continue;
+    switch (s.type) {
+      case 'taxi': drawTaxi(s.x); break;
+      case 'hotdog_cart': drawHotdogCart(s.x); break;
+      case 'fire_hydrant': drawFireHydrant(s.x); break;
+      case 'streetlamp': drawStreetlamp(s.x); break;
+      case 'pizza_shop': drawPizzaShop(s.x); break;
+      case 'central_park': drawCentralPark(s.x); break;
+      case 'statue_liberty': drawStatueLiberty(s.x); break;
+      case 'subway': drawSubwayEntrance(s.x); break;
+      case 'pigeon_flock': drawPigeons(s.x); break;
+    }
+  }
+}
+
+function drawTaxi(x) {
+  const gy = GROUND_Y;
+  // Body
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.roundRect(x - 30, gy - 22, 60, 18, 4); ctx.fill();
+  // Roof
+  ctx.fillStyle = '#eab308';
+  ctx.beginPath(); ctx.roundRect(x - 14, gy - 32, 28, 12, 4); ctx.fill();
+  // Windows
+  ctx.fillStyle = '#bae6fd';
+  ctx.fillRect(x - 12, gy - 30, 10, 8);
+  ctx.fillRect(x + 2, gy - 30, 10, 8);
+  // Wheels
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(x - 18, gy - 4, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 18, gy - 4, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#6b7280';
+  ctx.beginPath(); ctx.arc(x - 18, gy - 4, 3, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 18, gy - 4, 3, 0, Math.PI * 2); ctx.fill();
+  // TAXI sign
+  ctx.fillStyle = '#fff';
+  ctx.beginPath(); ctx.roundRect(x - 8, gy - 36, 16, 5, 2); ctx.fill();
+  ctx.fillStyle = '#1f2937';
+  ctx.font = 'bold 4px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('TAXI', x, gy - 32);
+}
+
+function drawHotdogCart(x) {
+  const gy = GROUND_Y;
+  // Cart body
+  ctx.fillStyle = '#dc2626';
+  ctx.beginPath(); ctx.roundRect(x - 25, gy - 35, 50, 25, 5); ctx.fill();
+  // Umbrella
+  ctx.fillStyle = '#2563eb';
+  ctx.beginPath(); ctx.arc(x, gy - 50, 30, Math.PI, 0); ctx.fill();
+  ctx.fillStyle = '#fbbf24';
+  // Umbrella stripes
+  for (let i = 0; i < 3; i++) {
+    ctx.beginPath();
+    ctx.arc(x, gy - 50, 30, Math.PI + i * 0.5, Math.PI + i * 0.5 + 0.25);
+    ctx.lineTo(x, gy - 50);
+    ctx.fill();
+  }
+  // Pole
+  ctx.fillStyle = '#94a3b8';
+  ctx.fillRect(x - 1, gy - 50, 2, 15);
+  // Wheels
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(x - 18, gy - 4, 5, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 18, gy - 4, 5, 0, Math.PI * 2); ctx.fill();
+  // HOT DOGS text
+  ctx.fillStyle = '#fbbf24';
+  ctx.font = 'bold 6px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('HOT DOGS', x, gy - 20);
+}
+
+function drawFireHydrant(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#ef4444';
+  ctx.beginPath(); ctx.roundRect(x - 6, gy - 22, 12, 22, 3); ctx.fill();
+  // Top cap
+  ctx.fillRect(x - 8, gy - 24, 16, 4);
+  // Side nozzles
+  ctx.fillRect(x - 10, gy - 16, 4, 4);
+  ctx.fillRect(x + 6, gy - 16, 4, 4);
+  // Highlight
+  ctx.fillStyle = 'rgba(255,255,255,0.2)';
+  ctx.fillRect(x - 2, gy - 20, 3, 16);
+}
+
+function drawStreetlamp(x) {
+  const gy = GROUND_Y;
+  // Pole
+  ctx.fillStyle = '#374151';
+  ctx.fillRect(x - 2, gy - 80, 4, 80);
+  // Arm
+  ctx.beginPath();
+  ctx.moveTo(x, gy - 75);
+  ctx.quadraticCurveTo(x + 15, gy - 78, x + 20, gy - 70);
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = '#374151';
+  ctx.stroke();
+  // Light
+  const cycle = (Math.sin(gameTime / DAY_LENGTH * Math.PI * 2 - Math.PI / 2) + 1) / 2;
+  if (cycle > 0.4) {
+    // Glow
+    ctx.globalAlpha = 0.15;
+    ctx.fillStyle = '#fde68a';
+    ctx.beginPath(); ctx.arc(x + 20, gy - 66, 30, 0, Math.PI * 2); ctx.fill();
+    ctx.globalAlpha = 1;
+  }
+  ctx.fillStyle = cycle > 0.4 ? '#fde68a' : '#d1d5db';
+  ctx.beginPath(); ctx.arc(x + 20, gy - 66, 5, 0, Math.PI * 2); ctx.fill();
+}
+
+function drawPizzaShop(x) {
+  const gy = GROUND_Y;
+  // Storefront
+  ctx.fillStyle = '#dc2626';
+  ctx.fillRect(x - 40, gy - 55, 80, 55);
+  // Window
+  ctx.fillStyle = '#fde68a';
+  ctx.fillRect(x - 32, gy - 45, 64, 30);
+  // Door
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(x - 8, gy - 35, 16, 35);
+  // Sign
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.roundRect(x - 30, gy - 60, 60, 10, 3); ctx.fill();
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 7px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('PIZZA', x, gy - 52.5);
+  // Pizza slice in window
+  ctx.fillStyle = '#f97316';
+  ctx.beginPath();
+  ctx.moveTo(x - 10, gy - 25);
+  ctx.lineTo(x, gy - 40);
+  ctx.lineTo(x + 10, gy - 25);
+  ctx.closePath();
+  ctx.fill();
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath();
+  ctx.moveTo(x - 8, gy - 27);
+  ctx.lineTo(x, gy - 38);
+  ctx.lineTo(x + 8, gy - 27);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function drawCentralPark(x) {
+  const gy = GROUND_Y;
+  // Green patch
+  ctx.fillStyle = '#4ade80';
+  ctx.beginPath();
+  ctx.ellipse(x, gy, 80, 6, 0, 0, Math.PI * 2);
+  ctx.fill();
+  // Trees
+  for (let i = -2; i <= 2; i++) {
+    const tx = x + i * 30;
+    ctx.fillStyle = '#78350f';
+    ctx.fillRect(tx - 3, gy - 40, 6, 40);
+    ctx.fillStyle = '#16a34a';
+    ctx.beginPath(); ctx.arc(tx, gy - 50, 18, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#22c55e';
+    ctx.beginPath(); ctx.arc(tx + 5, gy - 55, 14, 0, Math.PI * 2); ctx.fill();
+  }
+  // Bench
+  ctx.fillStyle = '#92400e';
+  ctx.fillRect(x - 15, gy - 12, 30, 3);
+  ctx.fillRect(x - 15, gy - 18, 30, 3);
+  ctx.fillRect(x - 14, gy - 12, 3, 12);
+  ctx.fillRect(x + 11, gy - 12, 3, 12);
+  // Sign
+  ctx.fillStyle = '#16a34a';
+  ctx.beginPath(); ctx.roundRect(x + 50, gy - 25, 30, 12, 2); ctx.fill();
+  ctx.fillStyle = '#fff';
+  ctx.font = '5px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('CENTRAL', x + 65, gy - 17);
+  ctx.fillText('PARK', x + 65, gy - 12);
+}
+
+function drawStatueLiberty(x) {
+  const gy = GROUND_Y;
+  // Pedestal
+  ctx.fillStyle = '#9ca3af';
+  ctx.fillRect(x - 20, gy - 30, 40, 30);
+  ctx.fillRect(x - 25, gy - 5, 50, 5);
+  // Body
+  ctx.fillStyle = '#86efac';
+  ctx.beginPath();
+  ctx.moveTo(x - 12, gy - 30);
+  ctx.lineTo(x - 8, gy - 80);
+  ctx.lineTo(x + 8, gy - 80);
+  ctx.lineTo(x + 12, gy - 30);
+  ctx.fill();
+  // Head
+  ctx.beginPath(); ctx.arc(x, gy - 88, 10, 0, Math.PI * 2); ctx.fill();
+  // Crown
+  ctx.fillStyle = '#86efac';
+  for (let i = 0; i < 7; i++) {
+    const a = Math.PI + (i / 6) * Math.PI;
+    ctx.beginPath();
+    ctx.moveTo(x, gy - 88);
+    ctx.lineTo(x + Math.cos(a) * 16, gy - 88 + Math.sin(a) * 16);
+    ctx.lineTo(x + Math.cos(a) * 14, gy - 88 + Math.sin(a) * 12);
+    ctx.fill();
+  }
+  // Torch arm
+  ctx.strokeStyle = '#86efac';
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.moveTo(x + 8, gy - 80);
+  ctx.lineTo(x + 20, gy - 105);
+  ctx.stroke();
+  // Torch flame
+  ctx.fillStyle = '#fbbf24';
+  const flicker = Math.sin(gameTime / 150) * 2;
+  ctx.beginPath();
+  ctx.moveTo(x + 16, gy - 105);
+  ctx.quadraticCurveTo(x + 20, gy - 118 + flicker, x + 24, gy - 105);
+  ctx.fill();
+  // Tablet
+  ctx.fillStyle = '#4ade80';
+  ctx.fillRect(x - 10, gy - 65, 8, 14);
+}
+
+function drawSubwayEntrance(x) {
+  const gy = GROUND_Y;
+  // Railing
+  ctx.fillStyle = '#16a34a';
+  ctx.fillRect(x - 25, gy - 25, 4, 25);
+  ctx.fillRect(x + 21, gy - 25, 4, 25);
+  ctx.fillRect(x - 25, gy - 25, 50, 4);
+  // Steps going down
+  ctx.fillStyle = '#6b7280';
+  for (let i = 0; i < 3; i++) {
+    ctx.fillRect(x - 20 + i * 3, gy - 4 + i * 3, 40 - i * 6, 4);
+  }
+  // Globe lamp
+  ctx.fillStyle = '#22c55e';
+  ctx.beginPath(); ctx.arc(x, gy - 30, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#4ade80';
+  ctx.beginPath(); ctx.arc(x, gy - 30, 4, 0, Math.PI * 2); ctx.fill();
+  // S sign
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 6px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('S', x, gy - 28);
+}
+
+function drawPigeons(x) {
+  for (let i = 0; i < 5; i++) {
+    const px = x + i * 16 - 32 + Math.sin(gameTime / 800 + i * 2) * 5;
+    const py = GROUND_Y - 6;
+    const facing = Math.sin(gameTime / 1200 + i * 3) > 0 ? 1 : -1;
+    ctx.save();
+    ctx.translate(px, py);
+    ctx.scale(facing, 1);
+    // Body
+    ctx.fillStyle = '#9ca3af';
+    ctx.beginPath(); ctx.ellipse(0, 0, 6, 4, 0, 0, Math.PI * 2); ctx.fill();
+    // Head
+    ctx.fillStyle = '#6b7280';
+    ctx.beginPath(); ctx.arc(5, -3, 3, 0, Math.PI * 2); ctx.fill();
+    // Neck shimmer
+    ctx.fillStyle = '#818cf8';
+    ctx.beginPath(); ctx.arc(4, -1, 2, 0, Math.PI * 2); ctx.fill();
+    // Eye
+    ctx.fillStyle = '#f97316';
+    ctx.beginPath(); ctx.arc(6, -4, 1, 0, Math.PI * 2); ctx.fill();
+    // Beak
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath();
+    ctx.moveTo(7, -3);
+    ctx.lineTo(10, -2.5);
+    ctx.lineTo(7, -2);
+    ctx.fill();
+    // Pecking animation
+    if (Math.sin(gameTime / 300 + i * 1.7) > 0.7) {
+      ctx.fillStyle = '#9ca3af';
+      ctx.beginPath(); ctx.arc(5, -1, 3, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.restore();
+  }
+}
+
+function lerpColor(a, b, t) {
+  return a.map((v, i) => Math.round(v + (b[i] - v) * t));
+}
+
+function drawStars(W, H) {
+  // deterministic stars
+  const seed = 42;
+  for (let i = 0; i < 60; i++) {
+    const sx = ((seed * (i + 1) * 7) % W);
+    const sy = ((seed * (i + 1) * 13) % (H * 0.5));
+    const twinkle = Math.sin(gameTime / 400 + i) * 0.3 + 0.7;
+    ctx.globalAlpha = twinkle * 0.8;
+    ctx.fillStyle = '#fff';
+    ctx.beginPath();
+    ctx.arc(sx, sy, 1.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawRainbow(W, H, cam) {
+  const colors = ['#ef4444','#f97316','#eab308','#22c55e','#3b82f6','#8b5cf6'];
+  const cx = WORLD_W / 2 - cam;
+  const cy = H * 0.15;
+  const baseR = 280;
+  ctx.globalAlpha = 0.35;
+  for (let i = 0; i < colors.length; i++) {
+    ctx.strokeStyle = colors[i];
+    ctx.lineWidth = 6;
+    ctx.beginPath();
+    ctx.arc(cx, cy + 100, baseR - i * 8, Math.PI, 0);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawCelestial(W, H, cycle) {
+  const angle = cycle * Math.PI;
+  const cx = W / 2 + Math.cos(angle + Math.PI) * (W * 0.35);
+  const cy = H * 0.15 - Math.sin(angle) * (H * 0.2) + H * 0.15;
+  if (cycle < 0.5) {
+    // Sun
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath();
+    ctx.arc(cx, cy, 24, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#fde68a';
+    ctx.beginPath();
+    ctx.arc(cx, cy, 28, 0, Math.PI * 2);
+    ctx.globalAlpha = 0.3;
+    ctx.fill();
+    ctx.globalAlpha = 1;
+  } else {
+    // Moon
+    ctx.fillStyle = '#e2e8f0';
+    ctx.beginPath();
+    ctx.arc(cx, cy, 20, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#1a1a2e';
+    ctx.beginPath();
+    ctx.arc(cx + 6, cy - 4, 16, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawHills(W, H, cam) {
+  // far hills
+  ctx.fillStyle = 'rgba(100, 160, 100, 0.3)';
+  ctx.beginPath();
+  ctx.moveTo(0, H);
+  for (let x = 0; x <= W; x += 10) {
+    const wx = x + cam * 0.2;
+    const y = H * 0.6 + Math.sin(wx / 200) * 30 + Math.sin(wx / 80) * 15;
+    ctx.lineTo(x, y);
+  }
+  ctx.lineTo(W, H);
+  ctx.fill();
+
+  // near hills
+  ctx.fillStyle = 'rgba(80, 140, 80, 0.4)';
+  ctx.beginPath();
+  ctx.moveTo(0, H);
+  for (let x = 0; x <= W; x += 10) {
+    const wx = x + cam * 0.5;
+    const y = H * 0.7 + Math.sin(wx / 150) * 20 + Math.sin(wx / 60) * 10;
+    ctx.lineTo(x, y);
+  }
+  ctx.lineTo(W, H);
+  ctx.fill();
+}
+
+function drawGround(W, H, cam) {
+  // Main ground
+  ctx.fillStyle = '#4ade80';
+  ctx.fillRect(0, GROUND_Y, WORLD_W, H);
+
+  // Grass detail
+  ctx.fillStyle = '#22c55e';
+  for (let x = 0; x < WORLD_W; x += 20) {
+    if (x > POND.x && x < POND.x + POND.w) continue;
+    ctx.fillRect(x, GROUND_Y - 2, 3, 6);
+    ctx.fillRect(x + 8, GROUND_Y - 1, 2, 4);
+  }
+
+  // Dirt layer
+  ctx.fillStyle = '#92400e';
+  ctx.fillRect(0, GROUND_Y + 40, WORLD_W, 200);
+}
+
+function drawPond() {
+  // Water
+  const waterGrad = ctx.createLinearGradient(POND.x, GROUND_Y, POND.x, GROUND_Y + POND.depth);
+  waterGrad.addColorStop(0, 'rgba(56, 189, 248, 0.6)');
+  waterGrad.addColorStop(1, 'rgba(14, 116, 144, 0.8)');
+  ctx.fillStyle = waterGrad;
+
+  // Pond shape (rounded)
+  ctx.beginPath();
+  ctx.moveTo(POND.x, GROUND_Y);
+  ctx.quadraticCurveTo(POND.x - 10, GROUND_Y + POND.depth / 2, POND.x + 20, GROUND_Y + POND.depth);
+  ctx.lineTo(POND.x + POND.w - 20, GROUND_Y + POND.depth);
+  ctx.quadraticCurveTo(POND.x + POND.w + 10, GROUND_Y + POND.depth / 2, POND.x + POND.w, GROUND_Y);
+  ctx.fill();
+
+  // Water shimmer
+  ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+  ctx.lineWidth = 1;
+  for (let i = 0; i < 5; i++) {
+    const sx = POND.x + 40 + i * 70;
+    const sy = GROUND_Y + 15 + Math.sin(gameTime / 500 + i) * 5;
+    ctx.beginPath();
+    ctx.moveTo(sx, sy);
+    ctx.lineTo(sx + 20, sy);
+    ctx.stroke();
+  }
+}
+
+function drawFish(f) {
+  ctx.save();
+  ctx.translate(f.x, f.y);
+  const dir = f.vx >= 0 ? 1 : -1;
+  ctx.scale(dir, 1);
+
+  // Body
+  ctx.fillStyle = f.color;
+  ctx.beginPath();
+  ctx.ellipse(0, 0, f.size, f.size * 0.6, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Tail
+  ctx.beginPath();
+  ctx.moveTo(-f.size, 0);
+  ctx.lineTo(-f.size - 8, -6);
+  ctx.lineTo(-f.size - 8, 6);
+  ctx.closePath();
+  ctx.fill();
+
+  // Eye (big googly)
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.arc(f.size * 0.4, -2, 5, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = '#000';
+  ctx.beginPath();
+  ctx.arc(f.size * 0.5, -2, 2.5, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Smile
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(f.size * 0.3, 3, 3, 0, Math.PI);
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+function drawGrill() {
+  const gx = GRILL.x, gy = GROUND_Y;
+
+  // Legs
+  ctx.fillStyle = '#404040';
+  ctx.fillRect(gx - 20, gy - 30, 4, 30);
+  ctx.fillRect(gx + 16, gy - 30, 4, 30);
+
+  // Grill body
+  ctx.fillStyle = '#525252';
+  ctx.fillRect(gx - 25, gy - 40, 50, 12);
+
+  // Grill grates
+  ctx.strokeStyle = '#737373';
+  ctx.lineWidth = 2;
+  for (let i = 0; i < 5; i++) {
+    ctx.beginPath();
+    ctx.moveTo(gx - 22 + i * 11, gy - 40);
+    ctx.lineTo(gx - 22 + i * 11, gy - 28);
+    ctx.stroke();
+  }
+
+  // Bacon on grill if cooking
+  if (cooking.active) {
+    const cookPct = cooking.progress / 3000;
+    const r = Math.round(255 - cookPct * 100);
+    const g = Math.round(180 - cookPct * 120);
+    const b = Math.round(180 - cookPct * 160);
+    ctx.fillStyle = `rgb(${r},${g},${b})`;
+    for (let i = 0; i < 3; i++) {
+      ctx.fillRect(gx - 15 + i * 12, gy - 38, 8, 3);
+      // wavy bacon
+      ctx.fillRect(gx - 14 + i * 12, gy - 35, 8, 3);
+    }
+
+    // Smoke
+    ctx.globalAlpha = 0.4;
+    ctx.fillStyle = '#d4d4d4';
+    for (let i = 0; i < 3; i++) {
+      const smokeY = gy - 50 - Math.sin(gameTime / 300 + i) * 10 - i * 12;
+      const smokeX = gx - 5 + Math.sin(gameTime / 500 + i * 2) * 8;
+      ctx.beginPath();
+      ctx.arc(smokeX, smokeY, 5 + i * 2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+  }
+}
+
+function drawBgScenes(cam, W) {
+  for (const s of bgScenes) {
+    // Skip if offscreen
+    if (s.x < cam - 200 || s.x > cam + W + 200) continue;
+    switch (s.type) {
+      case 'rv': drawRV(s.x, s.color); break;
+      case 'cactus': drawCactus(s.x, s.size); break;
+      case 'mushroom': drawMushrooms(s.x, s.count); break;
+      case 'flowers': drawFlowerGarden(s.x); break;
+      case 'campfire': drawCampfire(s.x); break;
+      case 'windmill': drawWindmill(s.x); break;
+      case 'crystals': drawCrystals(s.x); break;
+      case 'beehive': drawBeehive(s.x); break;
+      case 'waterfall': drawWaterfall(s.x); break;
+      case 'bridge': drawRainbowBridge(s.x); break;
+    }
+  }
+}
+
+function drawRV(x, color) {
+  const gy = GROUND_Y;
+  // Wheels
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(x - 25, gy - 4, 8, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 25, gy - 4, 8, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#6b7280';
+  ctx.beginPath(); ctx.arc(x - 25, gy - 4, 4, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 25, gy - 4, 4, 0, Math.PI * 2); ctx.fill();
+  // Body
+  ctx.fillStyle = color;
+  ctx.beginPath(); ctx.roundRect(x - 40, gy - 50, 80, 42, 6); ctx.fill();
+  // Roof
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(x - 38, gy - 54, 76, 6);
+  // Window
+  ctx.fillStyle = '#bae6fd';
+  ctx.fillRect(x - 28, gy - 44, 20, 16);
+  ctx.fillRect(x + 8, gy - 44, 20, 16);
+  // Door
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(x - 4, gy - 40, 12, 28);
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.arc(x + 5, gy - 26, 2, 0, Math.PI * 2); ctx.fill();
+  // Awning stripe
+  ctx.fillStyle = 'rgba(255,255,255,0.3)';
+  ctx.fillRect(x - 38, gy - 50, 76, 4);
+}
+
+function drawCactus(x, size) {
+  const gy = GROUND_Y;
+  const h = 50 * size;
+  ctx.fillStyle = '#22c55e';
+  // Main trunk
+  ctx.beginPath(); ctx.roundRect(x - 6 * size, gy - h, 12 * size, h, 5); ctx.fill();
+  // Left arm
+  ctx.beginPath(); ctx.roundRect(x - 20 * size, gy - h * 0.7, 14 * size, 8 * size, 4); ctx.fill();
+  ctx.beginPath(); ctx.roundRect(x - 20 * size, gy - h * 0.7 - 18 * size, 8 * size, 20 * size, 4); ctx.fill();
+  // Right arm
+  ctx.beginPath(); ctx.roundRect(x + 6 * size, gy - h * 0.5, 14 * size, 8 * size, 4); ctx.fill();
+  ctx.beginPath(); ctx.roundRect(x + 14 * size, gy - h * 0.5 - 14 * size, 8 * size, 16 * size, 4); ctx.fill();
+  // Highlights
+  ctx.fillStyle = 'rgba(255,255,255,0.15)';
+  ctx.fillRect(x - 2 * size, gy - h + 5, 3 * size, h - 10);
+  // Flower on top
+  ctx.fillStyle = '#f472b6';
+  ctx.beginPath(); ctx.arc(x, gy - h - 4, 4 * size, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.arc(x, gy - h - 4, 2 * size, 0, Math.PI * 2); ctx.fill();
+}
+
+function drawMushrooms(x, count) {
+  const gy = GROUND_Y;
+  const colors = ['#ef4444','#f472b6','#a78bfa','#fbbf24'];
+  for (let i = 0; i < count; i++) {
+    const mx = x + i * 28 - 40;
+    const mh = 14 + (i % 3) * 6;
+    const mc = colors[i % 4];
+    // Stem
+    ctx.fillStyle = '#fef3c7';
+    ctx.fillRect(mx - 3, gy - mh, 6, mh);
+    // Cap
+    ctx.fillStyle = mc;
+    ctx.beginPath(); ctx.arc(mx, gy - mh, 12, Math.PI, 0); ctx.fill();
+    // Spots
+    ctx.fillStyle = '#fff';
+    ctx.beginPath(); ctx.arc(mx - 4, gy - mh - 4, 2.5, 0, Math.PI * 2); ctx.fill();
+    ctx.beginPath(); ctx.arc(mx + 5, gy - mh - 2, 2, 0, Math.PI * 2); ctx.fill();
+  }
+}
+
+function drawFlowerGarden(x) {
+  const gy = GROUND_Y;
+  const flowerColors = ['#f43f5e','#fbbf24','#a78bfa','#38bdf8','#4ade80','#f472b6'];
+  for (let i = 0; i < 8; i++) {
+    const fx = x + i * 18 - 60;
+    const fh = 12 + Math.sin(i * 1.7) * 5;
+    // Stem
+    ctx.strokeStyle = '#16a34a';
+    ctx.lineWidth = 2;
+    ctx.beginPath(); ctx.moveTo(fx, gy); ctx.lineTo(fx, gy - fh); ctx.stroke();
+    // Leaf
+    if (i % 2 === 0) {
+      ctx.fillStyle = '#4ade80';
+      ctx.beginPath();
+      ctx.ellipse(fx + 4, gy - fh / 2, 4, 2, 0.5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // Petals
+    const fc = flowerColors[i % flowerColors.length];
+    ctx.fillStyle = fc;
+    for (let p = 0; p < 5; p++) {
+      const a = (p / 5) * Math.PI * 2 + gameTime / 2000;
+      ctx.beginPath();
+      ctx.arc(fx + Math.cos(a) * 4, gy - fh + Math.sin(a) * 4, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // Center
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath(); ctx.arc(fx, gy - fh, 2.5, 0, Math.PI * 2); ctx.fill();
+  }
+}
+
+function drawCampfire(x) {
+  const gy = GROUND_Y;
+  // Log seats
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.roundRect(x - 50, gy - 14, 30, 12, 4); ctx.fill();
+  ctx.beginPath(); ctx.roundRect(x + 20, gy - 14, 30, 12, 4); ctx.fill();
+  // Log rings
+  ctx.strokeStyle = '#92400e';
+  ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.ellipse(x - 50, gy - 8, 4, 6, 0, 0, Math.PI * 2); ctx.stroke();
+  ctx.beginPath(); ctx.ellipse(x + 50, gy - 8, 4, 6, 0, 0, Math.PI * 2); ctx.stroke();
+  // Fire pit stones
+  ctx.fillStyle = '#6b7280';
+  for (let i = 0; i < 6; i++) {
+    const a = (i / 6) * Math.PI * 2;
+    ctx.beginPath();
+    ctx.arc(x + Math.cos(a) * 12, gy - 4 + Math.sin(a) * 5, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  // Fire
+  const flicker = Math.sin(gameTime / 100) * 3;
+  ctx.fillStyle = '#f97316';
+  ctx.beginPath();
+  ctx.moveTo(x - 8, gy - 4);
+  ctx.quadraticCurveTo(x - 4, gy - 30 + flicker, x, gy - 4);
+  ctx.fill();
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath();
+  ctx.moveTo(x - 4, gy - 4);
+  ctx.quadraticCurveTo(x + 2, gy - 22 - flicker, x + 5, gy - 4);
+  ctx.fill();
+  ctx.fillStyle = '#fde68a';
+  ctx.beginPath();
+  ctx.moveTo(x - 2, gy - 4);
+  ctx.quadraticCurveTo(x, gy - 14 + flicker * 0.5, x + 3, gy - 4);
+  ctx.fill();
+  // Sparks
+  ctx.fillStyle = '#fbbf24';
+  for (let i = 0; i < 3; i++) {
+    const sy = gy - 30 - Math.sin(gameTime / 200 + i * 2) * 12;
+    const sx = x - 3 + Math.cos(gameTime / 300 + i * 3) * 8;
+    ctx.globalAlpha = 0.6;
+    ctx.beginPath(); ctx.arc(sx, sy, 1.5, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawWindmill(x) {
+  const gy = GROUND_Y;
+  // Tower
+  ctx.fillStyle = '#e5e7eb';
+  ctx.beginPath();
+  ctx.moveTo(x - 15, gy);
+  ctx.lineTo(x - 8, gy - 80);
+  ctx.lineTo(x + 8, gy - 80);
+  ctx.lineTo(x + 15, gy);
+  ctx.fill();
+  ctx.strokeStyle = '#d1d5db';
+  ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(x - 12, gy - 25); ctx.lineTo(x + 12, gy - 25); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(x - 10, gy - 50); ctx.lineTo(x + 10, gy - 50); ctx.stroke();
+  // Door
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.arc(x, gy - 8, 6, Math.PI, 0); ctx.fill();
+  ctx.fillRect(x - 6, gy - 8, 12, 8);
+  // Blades
+  const angle = gameTime / 1500;
+  ctx.strokeStyle = '#92400e';
+  ctx.lineWidth = 3;
+  for (let i = 0; i < 4; i++) {
+    const a = angle + (i / 4) * Math.PI * 2;
+    const bx = Math.cos(a) * 35;
+    const by = Math.sin(a) * 35;
+    ctx.beginPath();
+    ctx.moveTo(x, gy - 80);
+    ctx.lineTo(x + bx, gy - 80 + by);
+    ctx.stroke();
+    // Blade surface
+    ctx.fillStyle = 'rgba(210,180,140,0.5)';
+    ctx.beginPath();
+    ctx.moveTo(x, gy - 80);
+    ctx.lineTo(x + bx, gy - 80 + by);
+    ctx.lineTo(x + bx + Math.cos(a + 0.3) * 5, gy - 80 + by + Math.sin(a + 0.3) * 5);
+    ctx.fill();
+  }
+  // Hub
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.arc(x, gy - 80, 4, 0, Math.PI * 2); ctx.fill();
+}
+
+function drawCrystals(x) {
+  const gy = GROUND_Y;
+  const crystalData = [
+    { dx: -20, h: 35, w: 8, c: '#a78bfa' },
+    { dx: -8, h: 50, w: 10, c: '#c084fc' },
+    { dx: 6, h: 40, w: 9, c: '#818cf8' },
+    { dx: 18, h: 28, w: 7, c: '#e879f9' },
+    { dx: -14, h: 22, w: 6, c: '#c4b5fd' },
+  ];
+  for (const cr of crystalData) {
+    const shimmer = Math.sin(gameTime / 600 + cr.dx) * 0.15 + 0.85;
+    ctx.globalAlpha = shimmer;
+    ctx.fillStyle = cr.c;
+    ctx.beginPath();
+    ctx.moveTo(x + cr.dx, gy);
+    ctx.lineTo(x + cr.dx - cr.w / 2, gy - cr.h * 0.3);
+    ctx.lineTo(x + cr.dx, gy - cr.h);
+    ctx.lineTo(x + cr.dx + cr.w / 2, gy - cr.h * 0.3);
+    ctx.closePath();
+    ctx.fill();
+    // Highlight edge
+    ctx.fillStyle = 'rgba(255,255,255,0.3)';
+    ctx.beginPath();
+    ctx.moveTo(x + cr.dx, gy - cr.h);
+    ctx.lineTo(x + cr.dx + cr.w / 2, gy - cr.h * 0.3);
+    ctx.lineTo(x + cr.dx + 1, gy - cr.h * 0.5);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+  // Sparkle particles
+  ctx.fillStyle = '#fff';
+  for (let i = 0; i < 4; i++) {
+    const sy = gy - 20 - Math.sin(gameTime / 400 + i * 1.5) * 20;
+    const sx = x - 15 + Math.cos(gameTime / 500 + i * 2) * 25;
+    ctx.globalAlpha = Math.sin(gameTime / 300 + i) * 0.4 + 0.3;
+    ctx.beginPath(); ctx.arc(sx, sy, 1.5, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawBeehive(x) {
+  const gy = GROUND_Y;
+  // Tree trunk
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(x - 8, gy - 90, 16, 90);
+  // Bark lines
+  ctx.strokeStyle = '#92400e';
+  ctx.lineWidth = 1;
+  for (let i = 0; i < 4; i++) {
+    ctx.beginPath();
+    ctx.moveTo(x - 4, gy - 20 - i * 18);
+    ctx.lineTo(x - 2, gy - 14 - i * 18);
+    ctx.stroke();
+  }
+  // Foliage
+  ctx.fillStyle = '#16a34a';
+  ctx.beginPath(); ctx.arc(x, gy - 100, 28, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x - 18, gy - 88, 20, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 18, gy - 88, 20, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#22c55e';
+  ctx.beginPath(); ctx.arc(x + 8, gy - 108, 18, 0, Math.PI * 2); ctx.fill();
+  // Beehive
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.arc(x + 20, gy - 70, 12, 0, Math.PI * 2); ctx.fill();
+  // Hive stripes
+  ctx.strokeStyle = '#d97706';
+  ctx.lineWidth = 1.5;
+  for (let i = -2; i <= 2; i++) {
+    ctx.beginPath();
+    ctx.moveTo(x + 10, gy - 70 + i * 4);
+    ctx.lineTo(x + 30, gy - 70 + i * 4);
+    ctx.stroke();
+  }
+  // Hole
+  ctx.fillStyle = '#92400e';
+  ctx.beginPath(); ctx.arc(x + 20, gy - 66, 3, 0, Math.PI * 2); ctx.fill();
+  // Bees
+  for (let i = 0; i < 3; i++) {
+    const ba = gameTime / 400 + i * 2.1;
+    const bx = x + 20 + Math.cos(ba) * (18 + i * 5);
+    const by = gy - 70 + Math.sin(ba) * (12 + i * 4);
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath(); ctx.ellipse(bx, by, 3, 2, 0, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#1f2937';
+    ctx.fillRect(bx - 1, by - 2, 1, 4);
+    // Wings
+    ctx.fillStyle = 'rgba(255,255,255,0.6)';
+    ctx.beginPath(); ctx.ellipse(bx - 2, by - 3, 2, 1, -0.3, 0, Math.PI * 2); ctx.fill();
+  }
+}
+
+function drawWaterfall(x) {
+  const gy = GROUND_Y;
+  // Cliff rocks
+  ctx.fillStyle = '#6b7280';
+  ctx.beginPath();
+  ctx.moveTo(x - 30, gy);
+  ctx.lineTo(x - 25, gy - 70);
+  ctx.lineTo(x - 10, gy - 80);
+  ctx.lineTo(x + 10, gy - 80);
+  ctx.lineTo(x + 25, gy - 70);
+  ctx.lineTo(x + 30, gy);
+  ctx.fill();
+  // Rock detail
+  ctx.fillStyle = '#4b5563';
+  ctx.beginPath();
+  ctx.moveTo(x - 20, gy - 30);
+  ctx.lineTo(x - 10, gy - 50);
+  ctx.lineTo(x, gy - 30);
+  ctx.fill();
+  // Water stream
+  ctx.fillStyle = 'rgba(56, 189, 248, 0.6)';
+  ctx.fillRect(x - 6, gy - 75, 12, 75);
+  // Animated water lines
+  ctx.strokeStyle = 'rgba(255,255,255,0.4)';
+  ctx.lineWidth = 1.5;
+  for (let i = 0; i < 5; i++) {
+    const wy = ((gameTime / 8 + i * 15) % 75);
+    ctx.beginPath();
+    ctx.moveTo(x - 4, gy - 75 + wy);
+    ctx.lineTo(x + 4, gy - 75 + wy);
+    ctx.stroke();
+  }
+  // Splash at bottom
+  ctx.fillStyle = 'rgba(186, 230, 253, 0.5)';
+  const splash = Math.sin(gameTime / 200) * 3;
+  ctx.beginPath(); ctx.arc(x - 8, gy - 2, 6 + splash, Math.PI, 0); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 8, gy - 2, 5 - splash, Math.PI, 0); ctx.fill();
+  // Mist
+  ctx.globalAlpha = 0.2;
+  ctx.fillStyle = '#bae6fd';
+  ctx.beginPath(); ctx.arc(x, gy - 8, 20, 0, Math.PI * 2); ctx.fill();
+  ctx.globalAlpha = 1;
+}
+
+function drawRainbowBridge(x) {
+  const gy = GROUND_Y;
+  const colors = ['#ef4444','#f97316','#eab308','#22c55e','#3b82f6','#8b5cf6'];
+  // Bridge arc
+  for (let i = 0; i < colors.length; i++) {
+    ctx.strokeStyle = colors[i];
+    ctx.lineWidth = 5;
+    ctx.beginPath();
+    ctx.arc(x, gy, 50 + i * 6, Math.PI, 0);
+    ctx.stroke();
+  }
+  // Pillars
+  ctx.fillStyle = '#d1d5db';
+  ctx.fillRect(x - 52, gy - 30, 8, 30);
+  ctx.fillRect(x + 44, gy - 30, 8, 30);
+  // Sparkles on bridge
+  ctx.fillStyle = '#fff';
+  for (let i = 0; i < 6; i++) {
+    const a = Math.PI + (i / 5) * Math.PI * -1;
+    const r = 65 + Math.sin(gameTime / 300 + i) * 5;
+    ctx.globalAlpha = Math.sin(gameTime / 250 + i * 1.2) * 0.4 + 0.4;
+    ctx.beginPath();
+    ctx.arc(x + Math.cos(a) * r, gy + Math.sin(a) * r, 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawPlatforms() {
+  for (const p of platforms) {
+    // Platform shadow
+    ctx.fillStyle = 'rgba(0,0,0,0.1)';
+    ctx.fillRect(p.x + 3, p.y + 3, p.w, 14);
+
+    // Main platform body
+    const pGrad = ctx.createLinearGradient(p.x, p.y, p.x, p.y + 14);
+    pGrad.addColorStop(0, '#a78bfa');
+    pGrad.addColorStop(1, '#7c3aed');
+    ctx.fillStyle = pGrad;
+    ctx.beginPath();
+    ctx.roundRect(p.x, p.y, p.w, 14, 6);
+    ctx.fill();
+
+    // Grass tufts on top
+    ctx.fillStyle = '#4ade80';
+    for (let gx = p.x + 8; gx < p.x + p.w - 8; gx += 12) {
+      ctx.beginPath();
+      ctx.moveTo(gx - 3, p.y);
+      ctx.lineTo(gx, p.y - 5);
+      ctx.lineTo(gx + 3, p.y);
+      ctx.fill();
+    }
+
+    // Sparkle dots
+    ctx.fillStyle = 'rgba(255,255,255,0.5)';
+    ctx.beginPath();
+    ctx.arc(p.x + 10, p.y + 6, 2, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(p.x + p.w - 10, p.y + 6, 1.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawYarnBalls() {
+  for (const yb of yarnBalls) {
+    if (yb.collected) continue;
+    const bob = Math.sin(gameTime / 400 + yb.bobPhase) * 3;
+    const yx = yb.x, yy = yb.y + bob;
+
+    // Glow
+    ctx.globalAlpha = 0.25;
+    ctx.fillStyle = yb.color;
+    ctx.beginPath();
+    ctx.arc(yx, yy, 18, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+
+    // Ball body
+    ctx.fillStyle = yb.color;
+    ctx.beginPath();
+    ctx.arc(yx, yy, 12, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Yarn lines (cross-hatch pattern)
+    ctx.strokeStyle = 'rgba(255,255,255,0.4)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(yx, yy, 10, 0.3, 1.8);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(yx, yy, 8, 2.0, 3.5);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(yx, yy, 6, 4.0, 5.5);
+    ctx.stroke();
+
+    // Shine
+    ctx.fillStyle = 'rgba(255,255,255,0.6)';
+    ctx.beginPath();
+    ctx.arc(yx - 3, yy - 4, 3, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Trailing string
+    ctx.strokeStyle = yb.color;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(yx + 10, yy + 5);
+    ctx.quadraticCurveTo(yx + 16, yy + 12 + bob, yx + 12, yy + 18);
+    ctx.stroke();
+  }
+}
+
+function drawHouse() {
+  const hx = HOUSE.x, hy = GROUND_Y, hw = HOUSE.w, hh = HOUSE.h;
+
+  // Wall
+  ctx.fillStyle = '#fef3c7';
+  ctx.fillRect(hx, hy - hh, hw, hh);
+
+  // Roof
+  ctx.fillStyle = '#a855f7';
+  ctx.beginPath();
+  ctx.moveTo(hx - 15, hy - hh);
+  ctx.lineTo(hx + hw / 2, hy - hh - 60);
+  ctx.lineTo(hx + hw + 15, hy - hh);
+  ctx.closePath();
+  ctx.fill();
+
+  // Roof edge
+  ctx.strokeStyle = '#7c3aed';
+  ctx.lineWidth = 3;
+  ctx.stroke();
+
+  // Door
+  ctx.fillStyle = '#92400e';
+  ctx.fillRect(hx + hw / 2 - 15, hy - 50, 30, 50);
+  // Doorknob
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath();
+  ctx.arc(hx + hw / 2 + 8, hy - 25, 3, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Windows
+  ctx.fillStyle = '#bae6fd';
+  ctx.fillRect(hx + 15, hy - hh + 30, 30, 30);
+  ctx.fillRect(hx + hw - 45, hy - hh + 30, 30, 30);
+  // Window frames
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(hx + 15, hy - hh + 30, 30, 30);
+  ctx.strokeRect(hx + hw - 45, hy - hh + 30, 30, 30);
+  // Cross
+  ctx.beginPath();
+  ctx.moveTo(hx + 30, hy - hh + 30); ctx.lineTo(hx + 30, hy - hh + 60);
+  ctx.moveTo(hx + 15, hy - hh + 45); ctx.lineTo(hx + 45, hy - hh + 45);
+  ctx.stroke();
+
+  // Flower boxes
+  ctx.fillStyle = '#f472b6';
+  for (let i = 0; i < 3; i++) {
+    ctx.beginPath();
+    ctx.arc(hx + 18 + i * 7, hy - hh + 28, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawHouseInterior(cam, W, H) {
+  // Simple cozy interior
+  const cx = player.x;
+  const cy = GROUND_Y - 80;
+
+  // Floor
+  ctx.fillStyle = '#d4a574';
+  ctx.fillRect(cx - 200, cy, 400, 160);
+
+  // Back wall
+  ctx.fillStyle = '#fef3c7';
+  ctx.fillRect(cx - 200, cy - 140, 400, 140);
+
+  // Rug
+  ctx.fillStyle = '#c084fc';
+  ctx.beginPath();
+  ctx.ellipse(cx, cy + 40, 80, 30, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Fireplace
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(cx - 40, cy - 80, 80, 80);
+  ctx.fillStyle = '#f97316';
+  ctx.beginPath();
+  ctx.moveTo(cx - 20, cy);
+  ctx.quadraticCurveTo(cx, cy - 50, cx + 20, cy);
+  ctx.fill();
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath();
+  ctx.moveTo(cx - 10, cy);
+  ctx.quadraticCurveTo(cx, cy - 30, cx + 10, cy);
+  ctx.fill();
+
+  // Cozy text
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 18px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('Home sweet home!', cx, cy - 110);
+  ctx.font = '14px system-ui';
+  ctx.fillStyle = 'rgba(255,255,255,0.7)';
+  ctx.fillText('Press Enter to go outside', cx, cy + 130);
+
+  // Draw player inside
+  drawKitty(cx, cy + 60, player.color, 1, 0, 'horn');
+}
+
+function drawCamperInterior(cam, W, H) {
+  const cx = player.x;
+  const cy = GROUND_Y - 80;
+
+  // Floor (wood)
+  ctx.fillStyle = '#c4a882';
+  ctx.fillRect(cx - 200, cy, 400, 160);
+
+  // Back wall
+  ctx.fillStyle = '#fef9c3';
+  ctx.fillRect(cx - 200, cy - 140, 400, 140);
+
+  // Window with curtains
+  ctx.fillStyle = '#bae6fd';
+  ctx.fillRect(cx - 80, cy - 110, 60, 40);
+  ctx.fillRect(cx + 20, cy - 110, 60, 40);
+  ctx.fillStyle = '#f9a8d4';
+  ctx.fillRect(cx - 80, cy - 110, 12, 40);
+  ctx.fillRect(cx - 32, cy - 110, 12, 40);
+  ctx.fillRect(cx + 20, cy - 110, 12, 40);
+  ctx.fillRect(cx + 68, cy - 110, 12, 40);
+
+  // Bunk bed
+  ctx.fillStyle = '#92400e';
+  ctx.fillRect(cx + 120, cy - 60, 60, 60);
+  ctx.fillStyle = '#c084fc';
+  ctx.fillRect(cx + 124, cy - 56, 52, 20);
+  ctx.fillStyle = '#818cf8';
+  ctx.fillRect(cx + 124, cy - 20, 52, 16);
+
+  // Small kitchenette
+  ctx.fillStyle = '#d1d5db';
+  ctx.fillRect(cx - 180, cy - 40, 50, 40);
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(cx - 165, cy - 30, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(cx - 145, cy - 30, 6, 0, Math.PI * 2); ctx.fill();
+
+  // Cozy text
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 18px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('Cozy camper vibes!', cx, cy - 120);
+  ctx.font = '14px system-ui';
+  ctx.fillStyle = 'rgba(255,255,255,0.7)';
+  ctx.fillText('Press Enter to go outside', cx, cy + 130);
+
+  drawKitty(cx, cy + 60, player.color, 1, 0, 'horn');
+}
+
+function drawWindmillInterior(cam, W, H) {
+  const cx = player.x;
+  const cy = GROUND_Y - 80;
+
+  // Floor (stone)
+  ctx.fillStyle = '#9ca3af';
+  ctx.fillRect(cx - 180, cy, 360, 160);
+  // Stone pattern
+  ctx.strokeStyle = '#6b7280';
+  ctx.lineWidth = 1;
+  for (let sx = -180; sx < 180; sx += 30) {
+    for (let sy = 0; sy < 160; sy += 25) {
+      ctx.strokeRect(cx + sx, cy + sy, 30, 25);
+    }
+  }
+
+  // Curved stone walls
+  ctx.fillStyle = '#e5e7eb';
+  ctx.fillRect(cx - 180, cy - 150, 360, 150);
+
+  // Gear mechanism on the wall
+  ctx.strokeStyle = '#78350f';
+  ctx.lineWidth = 3;
+  const gearX = cx, gearY = cy - 90;
+  const gAngle = gameTime / 1500;
+  ctx.beginPath(); ctx.arc(gearX, gearY, 25, 0, Math.PI * 2); ctx.stroke();
+  for (let i = 0; i < 8; i++) {
+    const a = gAngle + (i / 8) * Math.PI * 2;
+    ctx.beginPath();
+    ctx.moveTo(gearX + Math.cos(a) * 20, gearY + Math.sin(a) * 20);
+    ctx.lineTo(gearX + Math.cos(a) * 30, gearY + Math.sin(a) * 30);
+    ctx.stroke();
+  }
+
+  // Flour sacks
+  ctx.fillStyle = '#fef3c7';
+  ctx.beginPath(); ctx.roundRect(cx - 140, cy - 30, 35, 30, 4); ctx.fill();
+  ctx.beginPath(); ctx.roundRect(cx - 100, cy - 30, 35, 30, 4); ctx.fill();
+  ctx.fillStyle = '#92400e';
+  ctx.font = '10px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('FLOUR', cx - 122, cy - 10);
+  ctx.fillText('FLOUR', cx - 82, cy - 10);
+
+  // Grindstone
+  ctx.fillStyle = '#6b7280';
+  ctx.beginPath(); ctx.arc(cx + 100, cy - 15, 20, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#4b5563';
+  ctx.beginPath(); ctx.arc(cx + 100, cy - 15, 10, 0, Math.PI * 2); ctx.fill();
+
+  // Text
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 18px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('The old windmill!', cx, cy - 130);
+  ctx.font = '14px system-ui';
+  ctx.fillStyle = 'rgba(255,255,255,0.7)';
+  ctx.fillText('Press Enter to go outside', cx, cy + 130);
+
+  drawKitty(cx, cy + 60, player.color, 1, 0, 'horn');
+}
+
+function drawPizzaInterior(cam, W, H) {
+  const cx = cam + W / 2;
+  const cy = GROUND_Y - 80;
+
+  // Kitchen floor (checkered)
+  ctx.fillStyle = '#f5f5f4';
+  ctx.fillRect(cam, cy, W, H);
+  ctx.fillStyle = '#e7e5e4';
+  for (let tx = -220; tx < 220; tx += 20) {
+    for (let ty = 0; ty < 160; ty += 20) {
+      if ((Math.floor(tx / 20) + Math.floor(ty / 20)) % 2 === 0) {
+        ctx.fillRect(cx + tx, cy + ty, 20, 20);
+      }
+    }
+  }
+
+  // Back wall (red)
+  ctx.fillStyle = '#dc2626';
+  ctx.fillRect(cam, 0, W, cy);
+
+  // Italian flag stripe
+  ctx.fillStyle = '#16a34a';
+  ctx.fillRect(cx - 220, cy - 140, 146, 8);
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(cx - 74, cy - 140, 148, 8);
+  ctx.fillStyle = '#dc2626';
+  ctx.fillRect(cx + 74, cy - 140, 146, 8);
+
+  // Pizza oven (brick)
+  ctx.fillStyle = '#92400e';
+  ctx.beginPath();
+  ctx.arc(cx + 100, cy - 30, 50, Math.PI, 0);
+  ctx.fillRect(cx + 50, cy - 30, 100, 30);
+  ctx.fill();
+  // Oven opening
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath();
+  ctx.arc(cx + 100, cy - 10, 25, Math.PI, 0);
+  ctx.fill();
+  // Fire glow inside oven
+  if (pizzaMaking.stage === 'oven') {
+    ctx.fillStyle = '#f97316';
+    ctx.globalAlpha = 0.6 + Math.sin(gameTime / 150) * 0.2;
+    ctx.beginPath();
+    ctx.arc(cx + 100, cy - 10, 22, Math.PI, 0);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+  }
+
+  // Counter
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(cx - 150, cy - 10, 180, 10);
+  // Counter top
+  ctx.fillStyle = '#d6d3d1';
+  ctx.fillRect(cx - 150, cy - 14, 180, 6);
+
+  // Pizza being made on counter
+  const pizzaX = cx - 60;
+  const pizzaY = cy - 24;
+
+  if (pizzaMaking.stage === 'dough') {
+    // Dough ball expanding
+    const doughSize = Math.min(20, 8 + pizzaMaking.progress / 100);
+    ctx.fillStyle = '#fde68a';
+    ctx.beginPath();
+    ctx.ellipse(pizzaX, pizzaY, doughSize, doughSize * 0.5, 0, 0, Math.PI * 2);
+    ctx.fill();
+    // Rolling pin
+    ctx.fillStyle = '#78350f';
+    ctx.beginPath();
+    ctx.roundRect(pizzaX - 25, pizzaY - 6, 50, 5, 2);
+    ctx.fill();
+  } else if (pizzaMaking.stage === 'toppings') {
+    // Flat dough
+    ctx.fillStyle = '#fde68a';
+    ctx.beginPath();
+    ctx.ellipse(pizzaX, pizzaY, 22, 11, 0, 0, Math.PI * 2);
+    ctx.fill();
+    // Sauce
+    ctx.fillStyle = '#dc2626';
+    ctx.beginPath();
+    ctx.ellipse(pizzaX, pizzaY, 18, 9, 0, 0, Math.PI * 2);
+    ctx.fill();
+    // Cheese
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath();
+    ctx.ellipse(pizzaX, pizzaY, 16, 8, 0, 0, Math.PI * 2);
+    ctx.fill();
+    // Toppings appearing
+    const numToppings = Math.min(6, Math.floor(pizzaMaking.progress / 200));
+    const toppingColors = ['#ef4444','#16a34a','#78350f','#f97316','#6b7280','#22c55e'];
+    for (let i = 0; i < numToppings; i++) {
+      const a = (i / 6) * Math.PI * 2 + 0.3;
+      ctx.fillStyle = toppingColors[i];
+      ctx.beginPath();
+      ctx.arc(pizzaX + Math.cos(a) * 10, pizzaY + Math.sin(a) * 5, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  } else if (pizzaMaking.stage === 'oven') {
+    // Pizza in oven — show timer bar
+    const pct = pizzaMaking.progress / 4500;
+    const barW = 120;
+    const barX = cx - barW / 2;
+    const barY = cy + 80;
+    // Bar background
+    ctx.fillStyle = 'rgba(0,0,0,0.3)';
+    ctx.beginPath(); ctx.roundRect(barX, barY, barW, 14, 4); ctx.fill();
+    // Bar fill (green → yellow → red)
+    let barColor;
+    if (pct < 0.66) barColor = '#4ade80';       // undercooked
+    else if (pct < 1.0) barColor = '#22c55e';    // perfect zone
+    else barColor = '#ef4444';                     // burning
+    ctx.fillStyle = barColor;
+    ctx.beginPath();
+    ctx.roundRect(barX + 2, barY + 2, Math.min(barW - 4, (barW - 4) * Math.min(pct, 1.33)), 10, 3);
+    ctx.fill();
+    // Perfect zone markers
+    ctx.fillStyle = 'rgba(255,255,255,0.5)';
+    ctx.fillRect(barX + (barW - 4) * 0.66 + 2, barY, 2, 14);
+    ctx.fillRect(barX + (barW - 4) * 1.0 + 2, barY, 2, 14);
+    // Label
+    ctx.fillStyle = '#fff';
+    ctx.font = '10px system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText('PERFECT', barX + barW * 0.83, barY - 4);
+  }
+
+  // Completed pizzas on shelf
+  for (let i = 0; i < Math.min(5, pizzaMaking.pizzaCount); i++) {
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath();
+    ctx.ellipse(cx - 180 + i * 28, cy - 90, 10, 5, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#dc2626';
+    ctx.beginPath();
+    ctx.ellipse(cx - 180 + i * 28, cy - 90, 8, 4, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // Title
+  ctx.fillStyle = '#fde68a';
+  ctx.font = 'bold 18px system-ui';
+  ctx.textAlign = 'center';
+  ctx.fillText('Pizza Kitchen!', cx, cy - 115);
+
+  // Instructions
+  ctx.font = '13px system-ui';
+  ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  if (pizzaMaking.stage === 'idle') {
+    ctx.fillText('Press C to start making a pizza', cx, cy + 120);
+    ctx.fillText('Press Enter to leave', cx, cy + 138);
+  } else if (pizzaMaking.stage === 'oven') {
+    ctx.fillText('Press C in the green zone!', cx, cy + 120);
+  }
+
+  // Draw player
+  drawKitty(cx - 60, cy + 60, player.color, 1, 0, 'horn');
+
+  // Popups
+  for (const p of popups) {
+    const alpha = Math.min(1, p.life / 500);
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = p.color;
+    ctx.font = 'bold 16px system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText(p.text, p.x, p.y);
+    ctx.globalAlpha = 1;
+  }
+}
+
+function drawParkInterior(cam, W, H) {
+  // Use cam-relative center so the scene is always centered on screen
+  const cx = cam + W / 2;
+  const cy = GROUND_Y - 80;
+  // Fill entire visible area
+  ctx.fillStyle = '#87ceeb';
+  ctx.fillRect(cam, 0, W, cy);
+  ctx.fillStyle = '#4ade80';
+  ctx.fillRect(cam, cy, W, H);
+  ctx.fillStyle = '#d4a574';
+  ctx.beginPath();
+  ctx.moveTo(cx - 250, cy + 60);
+  ctx.quadraticCurveTo(cx, cy + 40, cx + 250, cy + 70);
+  ctx.lineTo(cx + 250, cy + 80);
+  ctx.quadraticCurveTo(cx, cy + 60, cx - 250, cy + 70);
+  ctx.fill();
+  for (let i = -2; i <= 2; i++) {
+    const tx = cx + i * 90;
+    ctx.fillStyle = '#78350f';
+    ctx.fillRect(tx - 4, cy - 50, 8, 50);
+    ctx.fillStyle = '#16a34a';
+    ctx.beginPath(); ctx.arc(tx, cy - 60, 25, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#22c55e';
+    ctx.beginPath(); ctx.arc(tx + 8, cy - 68, 18, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.fillStyle = '#38bdf8';
+  ctx.beginPath(); ctx.ellipse(cx + 80, cy + 20, 40, 18, 0, 0, Math.PI * 2); ctx.fill();
+  for (let i = 0; i < 3; i++) {
+    const dx = cx + 65 + i * 15 + Math.sin(gameTime / 600 + i) * 5;
+    const dy = cy + 18 + Math.cos(gameTime / 800 + i) * 3;
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath(); ctx.ellipse(dx, dy, 5, 3, 0, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#f97316';
+    ctx.beginPath(); ctx.moveTo(dx + 4, dy - 1); ctx.lineTo(dx + 7, dy); ctx.lineTo(dx + 4, dy + 1); ctx.fill();
+  }
+  ctx.fillStyle = '#92400e';
+  const sq1x = cx - 100 + Math.sin(gameTime / 700) * 15;
+  ctx.beginPath(); ctx.ellipse(sq1x, cy + 90, 5, 4, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(sq1x + 4, cy + 86, 3, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(sq1x - 6, cy + 85, 4, 0, Math.PI * 2); ctx.fill();
+  const bfx = cx - 50 + Math.sin(gameTime / 500) * 40;
+  const bfy = cy - 20 + Math.cos(gameTime / 400) * 15;
+  ctx.fillStyle = '#e879f9';
+  const wing = Math.sin(gameTime / 100) * 4;
+  ctx.beginPath(); ctx.ellipse(bfx - 3, bfy, 3 + wing, 5, -0.3, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.ellipse(bfx + 3, bfy, 3 + wing, 5, 0.3, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#fff'; ctx.font = 'bold 18px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('Central Park', cx, cy - 130);
+  ctx.font = '13px system-ui'; ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  ctx.fillText('Press Enter to leave', cx, cy + 150);
+  drawKitty(cx - 30, cy + 60, player.color, 1, 0, 'horn');
+}
+
+function drawRomeSky(W, H, cycle, isNight) {
+  const dayTop = [150, 180, 230]; const nightTop = [15, 18, 35];
+  const dayBot = [255, 230, 200]; const nightBot = [30, 25, 45];
+  const skyTop = lerpColor(dayTop, nightTop, cycle);
+  const skyBot = lerpColor(dayBot, nightBot, cycle);
+  const grad = ctx.createLinearGradient(0, 0, 0, H);
+  grad.addColorStop(0, `rgb(${skyTop})`); grad.addColorStop(1, `rgb(${skyBot})`);
+  ctx.fillStyle = grad; ctx.fillRect(0, 0, W, H);
+  if (isNight) drawStars(W, H, cycle);
+  drawCelestial(W, H, cycle);
+}
+
+function drawRomeWorld(W, H, cam) {
+  const ww = getCurrentWorldW();
+  ctx.fillStyle = '#a8a29e'; ctx.fillRect(0, GROUND_Y, ww, H);
+  ctx.strokeStyle = '#78716c'; ctx.lineWidth = 0.5;
+  for (let rx = Math.max(0, Math.floor((cam - 20) / 24) * 24); rx < Math.min(ww, cam + W + 20); rx += 24) {
+    for (let ry = 0; ry < 3; ry++) {
+      const offset = ry % 2 === 0 ? 0 : 12;
+      ctx.beginPath(); ctx.roundRect(rx + offset, GROUND_Y + 4 + ry * 10, 20, 8, 2); ctx.stroke();
+    }
+  }
+  drawRomeScenes(cam, W); drawRomePlatforms(); drawRomeYarnBalls();
+  for (const npc of romeNpcs) drawKitty(npc.x, npc.y, npc.color, npc.facing, npc.walkFrame, npc.accessory);
+  drawPlayerAndUI();
+}
+
+function drawRomePlatforms() {
+  for (const p of level3.platforms) {
+    ctx.fillStyle = 'rgba(0,0,0,0.1)'; ctx.fillRect(p.x + 3, p.y + 3, p.w, 14);
+    const pGrad = ctx.createLinearGradient(p.x, p.y, p.x, p.y + 14);
+    pGrad.addColorStop(0, '#d6d3d1'); pGrad.addColorStop(1, '#a8a29e');
+    ctx.fillStyle = pGrad; ctx.beginPath(); ctx.roundRect(p.x, p.y, p.w, 14, 4); ctx.fill();
+    ctx.strokeStyle = 'rgba(0,0,0,0.15)'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(p.x + 5, p.y + 7); ctx.lineTo(p.x + p.w - 5, p.y + 7); ctx.stroke();
+  }
+}
+
+function drawRomeYarnBalls() {
+  for (const yb of level3.yarnBalls) {
+    if (yb.collected) continue;
+    const bob = Math.sin(gameTime / 400 + yb.bobPhase) * 3;
+    const yx = yb.x, yy = yb.y + bob;
+    ctx.globalAlpha = 0.25; ctx.fillStyle = yb.color;
+    ctx.beginPath(); ctx.arc(yx, yy, 18, 0, Math.PI * 2); ctx.fill(); ctx.globalAlpha = 1;
+    ctx.fillStyle = yb.color; ctx.beginPath(); ctx.arc(yx, yy, 12, 0, Math.PI * 2); ctx.fill();
+    ctx.strokeStyle = 'rgba(255,255,255,0.4)'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.arc(yx, yy, 10, 0.3, 1.8); ctx.stroke();
+    ctx.beginPath(); ctx.arc(yx, yy, 8, 2.0, 3.5); ctx.stroke();
+    ctx.fillStyle = 'rgba(255,255,255,0.6)';
+    ctx.beginPath(); ctx.arc(yx - 3, yy - 4, 3, 0, Math.PI * 2); ctx.fill();
+    ctx.strokeStyle = yb.color; ctx.lineWidth = 1.5;
+    ctx.beginPath(); ctx.moveTo(yx + 10, yy + 5);
+    ctx.quadraticCurveTo(yx + 16, yy + 12 + bob, yx + 12, yy + 18); ctx.stroke();
+  }
+}
+
+function drawRomeScenes(cam, W) {
+  for (const s of level3.scenes) {
+    if (s.x < cam - 250 || s.x > cam + W + 250) continue;
+    switch (s.type) {
+      case 'colosseum': drawColosseum(s.x); break;
+      case 'fountain': drawFountain(s.x); break;
+      case 'roman_column': drawRomanColumn(s.x); break;
+      case 'gelato_cart': drawGelatoCart(s.x); break;
+      case 'vespa': drawVespa(s.x); break;
+      case 'olive_tree': drawOliveTree(s.x); break;
+      case 'pantheon': drawPantheon(s.x); break;
+      case 'pasta_shop': drawPastaShop(s.x); break;
+      case 'leaning_tower': drawLeaningTower(s.x); break;
+      case 'piazza': drawPiazza(s.x); break;
+      case 'fiat': drawFiat(s.x); break;
+    }
+  }
+}
+
+function drawColosseum(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#d6d3d1';
+  ctx.beginPath(); ctx.ellipse(x, gy - 50, 80, 60, 0, Math.PI, 0); ctx.fill();
+  ctx.fillRect(x - 80, gy - 50, 160, 50);
+  ctx.fillStyle = '#78716c';
+  for (let tier = 0; tier < 3; tier++) {
+    const ty = gy - 85 + tier * 22;
+    const numArches = 8 - tier;
+    const archW = 140 / numArches;
+    for (let i = 0; i < numArches; i++) {
+      const ax = x - 70 + i * archW + archW / 2;
+      ctx.beginPath(); ctx.arc(ax, ty + 8, archW / 2 - 2, Math.PI, 0); ctx.fill();
+    }
+  }
+  ctx.fillStyle = '#d6d3d1';
+  for (let i = 0; i < 8; i++) {
+    const bh = Math.sin(i * 1.3) * 8 + 5;
+    ctx.fillRect(x - 75 + i * 20, gy - 110 - bh, 15, bh);
+  }
+}
+
+function drawFountain(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#d6d3d1';
+  ctx.beginPath(); ctx.ellipse(x, gy - 8, 40, 12, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#38bdf8';
+  ctx.beginPath(); ctx.ellipse(x, gy - 10, 35, 9, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#d6d3d1'; ctx.fillRect(x - 4, gy - 45, 8, 35);
+  ctx.beginPath(); ctx.ellipse(x, gy - 45, 15, 6, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.strokeStyle = '#38bdf8'; ctx.lineWidth = 2;
+  const jt = Math.sin(gameTime / 200) * 3;
+  for (let i = -1; i <= 1; i++) {
+    ctx.beginPath(); ctx.moveTo(x + i * 8, gy - 45);
+    ctx.quadraticCurveTo(x + i * 15, gy - 60 + jt, x + i * 20, gy - 15); ctx.stroke();
+  }
+  ctx.fillStyle = '#fff';
+  for (let i = 0; i < 4; i++) {
+    ctx.globalAlpha = Math.sin(gameTime / 200 + i) * 0.3 + 0.3;
+    ctx.beginPath(); ctx.arc(x - 10 + Math.cos(gameTime / 300 + i * 1.5) * 20, gy - 30 + Math.sin(gameTime / 250 + i * 2) * 15, 1.5, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+}
+
+function drawRomanColumn(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#d6d3d1';
+  ctx.fillRect(x - 10, gy - 8, 20, 8); ctx.fillRect(x - 6, gy - 70, 12, 62); ctx.fillRect(x - 10, gy - 74, 20, 6);
+  ctx.strokeStyle = 'rgba(0,0,0,0.1)'; ctx.lineWidth = 1;
+  for (let i = -2; i <= 2; i++) { ctx.beginPath(); ctx.moveTo(x + i * 2, gy - 8); ctx.lineTo(x + i * 2, gy - 70); ctx.stroke(); }
+}
+
+function drawGelatoCart(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#fff'; ctx.beginPath(); ctx.roundRect(x - 25, gy - 35, 50, 28, 5); ctx.fill();
+  ctx.fillStyle = '#16a34a'; ctx.beginPath(); ctx.arc(x, gy - 50, 28, Math.PI, Math.PI + Math.PI / 3); ctx.lineTo(x, gy - 50); ctx.fill();
+  ctx.fillStyle = '#fff'; ctx.beginPath(); ctx.arc(x, gy - 50, 28, Math.PI + Math.PI / 3, Math.PI + 2 * Math.PI / 3); ctx.lineTo(x, gy - 50); ctx.fill();
+  ctx.fillStyle = '#dc2626'; ctx.beginPath(); ctx.arc(x, gy - 50, 28, Math.PI + 2 * Math.PI / 3, 0); ctx.lineTo(x, gy - 50); ctx.fill();
+  ctx.fillStyle = '#94a3b8'; ctx.fillRect(x - 1, gy - 50, 2, 15);
+  const gc = ['#fda4af','#86efac','#fde68a','#c4b5fd'];
+  for (let i = 0; i < 4; i++) { ctx.fillStyle = gc[i]; ctx.beginPath(); ctx.arc(x - 15 + i * 10, gy - 25, 5, Math.PI, 0); ctx.fill(); }
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(x - 18, gy - 4, 5, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 18, gy - 4, 5, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#78350f'; ctx.font = 'bold 5px system-ui'; ctx.textAlign = 'center'; ctx.fillText('GELATO', x, gy - 12);
+}
+
+function drawVespa(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#ef4444'; ctx.beginPath(); ctx.roundRect(x - 18, gy - 22, 36, 16, 6); ctx.fill();
+  ctx.fillStyle = '#78350f'; ctx.beginPath(); ctx.roundRect(x - 8, gy - 26, 20, 6, 3); ctx.fill();
+  ctx.strokeStyle = '#94a3b8'; ctx.lineWidth = 2;
+  ctx.beginPath(); ctx.moveTo(x - 14, gy - 22); ctx.lineTo(x - 18, gy - 30); ctx.stroke();
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(x - 14, gy - 4, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 14, gy - 4, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#fde68a'; ctx.beginPath(); ctx.arc(x - 18, gy - 16, 3, 0, Math.PI * 2); ctx.fill();
+}
+
+function drawOliveTree(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.moveTo(x - 5, gy); ctx.quadraticCurveTo(x - 8, gy - 25, x - 3, gy - 45);
+  ctx.lineTo(x + 3, gy - 45); ctx.quadraticCurveTo(x + 8, gy - 25, x + 5, gy); ctx.fill();
+  ctx.fillStyle = '#6b8e6b';
+  ctx.beginPath(); ctx.arc(x, gy - 55, 22, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x - 14, gy - 48, 16, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 14, gy - 48, 16, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#365314';
+  for (let i = 0; i < 5; i++) { ctx.beginPath(); ctx.arc(x - 12 + i * 6, gy - 42 + Math.cos(i * 1.7) * 8, 2.5, 0, Math.PI * 2); ctx.fill(); }
+}
+
+function drawPantheon(x) {
+  const gy = GROUND_Y;
+  for (let i = 0; i < 6; i++) {
+    const cx2 = x - 50 + i * 20;
+    ctx.fillStyle = '#d6d3d1'; ctx.fillRect(cx2 - 3, gy - 80, 6, 80); ctx.fillRect(cx2 - 5, gy - 82, 10, 4);
+  }
+  ctx.fillStyle = '#d6d3d1';
+  ctx.beginPath(); ctx.moveTo(x - 55, gy - 82); ctx.lineTo(x, gy - 105); ctx.lineTo(x + 55, gy - 82); ctx.closePath(); ctx.fill();
+  ctx.fillStyle = '#a8a29e'; ctx.beginPath(); ctx.arc(x, gy - 60, 50, Math.PI, 0); ctx.fill();
+  ctx.fillStyle = '#78716c'; ctx.font = 'bold 5px system-ui'; ctx.textAlign = 'center'; ctx.fillText('PANTHEON', x, gy - 90);
+}
+
+function drawPastaShop(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#fef3c7'; ctx.fillRect(x - 35, gy - 50, 70, 50);
+  ctx.fillStyle = '#16a34a'; ctx.fillRect(x - 38, gy - 50, 76, 8);
+  for (let i = 0; i < 6; i++) { ctx.beginPath(); ctx.arc(x - 30 + i * 12, gy - 42, 6, 0, Math.PI); ctx.fill(); }
+  ctx.fillStyle = '#fde68a'; ctx.fillRect(x - 25, gy - 38, 50, 20);
+  ctx.fillStyle = '#78350f'; ctx.beginPath(); ctx.roundRect(x - 8, gy - 30, 16, 30, [4, 4, 0, 0]); ctx.fill();
+  ctx.strokeStyle = '#fbbf24'; ctx.lineWidth = 1.5;
+  for (let i = 0; i < 4; i++) { ctx.beginPath(); ctx.moveTo(x - 20 + i * 12, gy - 36); ctx.lineTo(x - 20 + i * 12, gy - 22); ctx.stroke(); }
+  ctx.fillStyle = '#dc2626'; ctx.font = 'bold 6px system-ui'; ctx.textAlign = 'center'; ctx.fillText('PASTA', x, gy - 52);
+}
+
+function drawPiazza(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#e7e5e4'; ctx.beginPath(); ctx.ellipse(x, gy, 70, 8, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#a8a29e';
+  ctx.beginPath(); ctx.moveTo(x - 4, gy); ctx.lineTo(x - 3, gy - 50); ctx.lineTo(x, gy - 60);
+  ctx.lineTo(x + 3, gy - 50); ctx.lineTo(x + 4, gy); ctx.fill();
+  ctx.fillStyle = '#78350f'; ctx.fillRect(x - 50, gy - 10, 20, 4); ctx.fillRect(x + 30, gy - 10, 20, 4);
+  for (let i = 0; i < 4; i++) {
+    const px = x - 30 + i * 20 + Math.sin(gameTime / 600 + i * 2) * 8;
+    ctx.fillStyle = '#9ca3af'; ctx.beginPath(); ctx.ellipse(px, gy - 4, 4, 3, 0, 0, Math.PI * 2); ctx.fill();
+  }
+}
+
+function drawLeaningTower(x) {
+  const gy = GROUND_Y;
+  ctx.save();
+  ctx.translate(x, gy);
+  ctx.rotate(-0.08); // the lean!
+  // Tower body (8 tiers)
+  ctx.fillStyle = '#e7e5e4';
+  for (let i = 0; i < 8; i++) {
+    const tw = 30 - i * 1.5;
+    const ty = -i * 15 - 10;
+    ctx.fillRect(-tw / 2, ty - 15, tw, 15);
+    // Columns on each tier
+    ctx.fillStyle = '#d6d3d1';
+    for (let c = 0; c < 4; c++) {
+      const cx2 = -tw / 2 + 3 + c * ((tw - 6) / 3);
+      ctx.fillRect(cx2, ty - 13, 2, 11);
+    }
+    // Arches
+    ctx.fillStyle = '#a8a29e';
+    for (let c = 0; c < 3; c++) {
+      const ax = -tw / 2 + 5 + c * ((tw - 10) / 2);
+      ctx.beginPath();
+      ctx.arc(ax + 3, ty - 8, 3, Math.PI, 0);
+      ctx.fill();
+    }
+    ctx.fillStyle = '#e7e5e4';
+  }
+  // Top dome
+  ctx.fillStyle = '#d6d3d1';
+  ctx.beginPath();
+  ctx.arc(0, -130, 8, Math.PI, 0);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawPantheonInterior(cam, W, H) {
+  const cx = cam + W / 2;
+  const cy = GROUND_Y - 80;
+  // Stone walls
+  ctx.fillStyle = '#d6d3d1';
+  ctx.fillRect(cam, 0, W, H);
+  // Marble floor
+  ctx.fillStyle = '#e7e5e4';
+  ctx.fillRect(cam, cy, W, H);
+  // Floor pattern (radial marble tiles)
+  ctx.strokeStyle = '#a8a29e';
+  ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.arc(cx, cy + 60, 80, 0, Math.PI * 2); ctx.stroke();
+  ctx.beginPath(); ctx.arc(cx, cy + 60, 50, 0, Math.PI * 2); ctx.stroke();
+  ctx.beginPath(); ctx.arc(cx, cy + 60, 20, 0, Math.PI * 2); ctx.stroke();
+  // Dome with oculus (ceiling)
+  ctx.fillStyle = '#a8a29e';
+  ctx.beginPath(); ctx.arc(cx, cy - 60, 150, Math.PI, 0); ctx.fill();
+  // Oculus (hole in dome)
+  ctx.fillStyle = '#87ceeb';
+  ctx.beginPath(); ctx.arc(cx, cy - 100, 30, 0, Math.PI * 2); ctx.fill();
+  // Sunbeam from oculus
+  ctx.globalAlpha = 0.08;
+  ctx.fillStyle = '#fde68a';
+  ctx.beginPath();
+  ctx.moveTo(cx - 28, cy - 100);
+  ctx.lineTo(cx - 40, cy + 80);
+  ctx.lineTo(cx + 40, cy + 80);
+  ctx.lineTo(cx + 28, cy - 100);
+  ctx.fill();
+  ctx.globalAlpha = 1;
+  // Dome coffers (indented squares)
+  ctx.strokeStyle = '#78716c';
+  ctx.lineWidth = 1;
+  for (let ring = 0; ring < 4; ring++) {
+    const r = 60 + ring * 25;
+    const num = 8 + ring * 2;
+    for (let i = 0; i < num; i++) {
+      const a = Math.PI + (i / num) * Math.PI;
+      const ax = cx + Math.cos(a) * r;
+      const ay = cy - 60 + Math.sin(a) * r * 0.5;
+      ctx.strokeRect(ax - 5, ay - 4, 10, 8);
+    }
+  }
+  // Columns along walls
+  ctx.fillStyle = '#c4b5a0';
+  for (let i = 0; i < 8; i++) {
+    const colX = cx - 180 + i * 52;
+    ctx.fillRect(colX, cy - 50, 8, 130);
+    ctx.fillRect(colX - 2, cy - 52, 12, 4);
+  }
+  // Statues in niches
+  ctx.fillStyle = '#d6d3d1';
+  for (let i = 0; i < 3; i++) {
+    const sx = cx - 120 + i * 120;
+    ctx.fillRect(sx - 8, cy - 30, 16, 30);
+    ctx.beginPath(); ctx.arc(sx, cy - 35, 6, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.fillStyle = '#fff'; ctx.font = 'bold 18px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('The Pantheon', cx, cy - 130);
+  ctx.font = '13px system-ui'; ctx.fillStyle = 'rgba(100,100,100,0.8)';
+  ctx.fillText('Press Enter to leave', cx, cy + 145);
+  drawKitty(cx, cy + 60, player.color, 1, 0, 'horn');
+}
+
+function drawSwimmingScene(cam, W, H) {
+  const cx = cam + W / 2;
+  const cy = GROUND_Y - 40;
+  // Sky
+  ctx.fillStyle = '#87ceeb';
+  ctx.fillRect(cam, 0, W, cy - 40);
+  // Fountain basin
+  ctx.fillStyle = '#d6d3d1';
+  ctx.beginPath(); ctx.ellipse(cx, cy + 10, 200, 50, 0, 0, Math.PI * 2); ctx.fill();
+  // Water
+  ctx.fillStyle = '#38bdf8';
+  ctx.beginPath(); ctx.ellipse(cx, cy + 8, 190, 45, 0, 0, Math.PI * 2); ctx.fill();
+  // Animated waves
+  ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+  ctx.lineWidth = 2;
+  for (let i = 0; i < 8; i++) {
+    const wx = cx - 150 + i * 40 + Math.sin(gameTime / 300 + i) * 10;
+    const wy = cy + Math.sin(gameTime / 400 + i * 0.8) * 5;
+    ctx.beginPath(); ctx.moveTo(wx, wy); ctx.lineTo(wx + 20, wy); ctx.stroke();
+  }
+  // Water jets
+  ctx.strokeStyle = '#93c5fd';
+  ctx.lineWidth = 3;
+  const jt = Math.sin(gameTime / 200) * 4;
+  ctx.beginPath(); ctx.moveTo(cx, cy - 10);
+  ctx.quadraticCurveTo(cx, cy - 60 + jt, cx, cy - 50); ctx.stroke();
+  for (let i = -1; i <= 1; i += 2) {
+    ctx.beginPath(); ctx.moveTo(cx, cy - 10);
+    ctx.quadraticCurveTo(cx + i * 30, cy - 50 + jt, cx + i * 50, cy); ctx.stroke();
+  }
+  // Splash particles
+  ctx.fillStyle = '#bae6fd';
+  for (let i = 0; i < 6; i++) {
+    const sx = cx - 60 + Math.cos(gameTime / 200 + i * 1.1) * 80;
+    const sy = cy - 10 + Math.sin(gameTime / 250 + i * 1.5) * 15;
+    ctx.globalAlpha = 0.5;
+    ctx.beginPath(); ctx.arc(sx, sy, 3, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+  // Draw kitty bobbing in the water
+  const kittyBob = Math.sin(gameTime / 300) * 4;
+  drawKitty(cx, cy + kittyBob, player.color, 1, Math.floor(gameTime / 200) % 4, 'horn');
+  // Water overlay (kitty partially submerged)
+  ctx.fillStyle = 'rgba(56, 189, 248, 0.4)';
+  ctx.beginPath(); ctx.ellipse(cx, cy + 8, 190, 45, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#fff'; ctx.font = 'bold 18px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('Splashing in the fountain!', cx, cy - 80);
+  ctx.font = '13px system-ui'; ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  ctx.fillText('Press S to get out', cx, cy + 80);
+}
+
+// ── Fiat (Rome portal to Hawaii) ──
+function drawFiat(x) {
+  const gy = GROUND_Y;
+  // Body
+  ctx.fillStyle = '#22d3ee';
+  ctx.beginPath(); ctx.roundRect(x - 22, gy - 24, 44, 18, 6); ctx.fill();
+  // Roof
+  ctx.fillStyle = '#06b6d4';
+  ctx.beginPath(); ctx.roundRect(x - 12, gy - 34, 28, 12, [6, 6, 0, 0]); ctx.fill();
+  // Windshield
+  ctx.fillStyle = '#bae6fd';
+  ctx.beginPath(); ctx.roundRect(x - 9, gy - 32, 10, 8, 2); ctx.fill();
+  ctx.beginPath(); ctx.roundRect(x + 2, gy - 32, 10, 8, 2); ctx.fill();
+  // Wheels
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(x - 14, gy - 4, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 14, gy - 4, 6, 0, Math.PI * 2); ctx.fill();
+  // Hubcaps
+  ctx.fillStyle = '#9ca3af';
+  ctx.beginPath(); ctx.arc(x - 14, gy - 4, 3, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 14, gy - 4, 3, 0, Math.PI * 2); ctx.fill();
+  // Headlights
+  ctx.fillStyle = '#fde68a';
+  ctx.beginPath(); ctx.arc(x + 22, gy - 18, 3, 0, Math.PI * 2); ctx.fill();
+  // FIAT label
+  ctx.fillStyle = '#1f2937'; ctx.font = 'bold 5px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('FIAT', x, gy - 36);
+  // Arrow glow (portal indicator)
+  ctx.globalAlpha = 0.5 + Math.sin(gameTime / 300) * 0.3;
+  ctx.fillStyle = '#fbbf24'; ctx.font = 'bold 10px system-ui';
+  ctx.fillText('>>>', x + 32, gy - 20);
+  ctx.globalAlpha = 1;
+}
+
+// ── Hawaii Draw Functions ──
+function drawHawaiiSky(W, H, cycle, isNight) {
+  const dayTop = [80, 200, 255]; const nightTop = [10, 20, 45];
+  const dayBot = [255, 180, 120]; const nightBot = [30, 20, 50];
+  const skyTop = lerpColor(dayTop, nightTop, cycle);
+  const skyBot = lerpColor(dayBot, nightBot, cycle);
+  const grad = ctx.createLinearGradient(0, 0, 0, H);
+  grad.addColorStop(0, `rgb(${skyTop})`); grad.addColorStop(0.7, `rgb(${skyBot})`);
+  grad.addColorStop(1, '#38bdf8');
+  ctx.fillStyle = grad; ctx.fillRect(0, 0, W, H);
+  if (isNight) drawStars(W, H, cycle);
+  if (isNight) drawRainbow(W, H, 0);
+  drawCelestial(W, H, cycle);
+}
+
+function drawHawaiiWorld(W, H, cam) {
+  const ww = getCurrentWorldW();
+  // Ocean below ground
+  ctx.fillStyle = '#0ea5e9';
+  ctx.fillRect(0, GROUND_Y, ww, H);
+  // Animated waves on the ocean
+  ctx.strokeStyle = 'rgba(255,255,255,0.2)'; ctx.lineWidth = 2;
+  for (let wx = Math.floor((cam - 20) / 40) * 40; wx < cam + W + 40; wx += 40) {
+    const wy = GROUND_Y + 8 + Math.sin(gameTime / 400 + wx * 0.05) * 3;
+    ctx.beginPath(); ctx.moveTo(wx, wy); ctx.quadraticCurveTo(wx + 20, wy - 4, wx + 40, wy); ctx.stroke();
+  }
+  // Sandy beach strip
+  ctx.fillStyle = '#fde68a';
+  ctx.fillRect(0, GROUND_Y - 4, ww, 8);
+  // Beach details (shells, footprints)
+  ctx.fillStyle = '#d97706';
+  for (let sx = Math.floor((cam - 10) / 120) * 120; sx < cam + W + 10; sx += 120) {
+    ctx.beginPath(); ctx.arc(sx + 30, GROUND_Y, 2, 0, Math.PI * 2); ctx.fill();
+    ctx.beginPath(); ctx.arc(sx + 80, GROUND_Y + 1, 1.5, 0, Math.PI * 2); ctx.fill();
+  }
+  drawHawaiiScenes(cam, W);
+  drawHawaiiPlatforms();
+  drawHawaiiYarnBalls();
+  for (const npc of hawaiiNpcs) drawKitty(npc.x, npc.y, npc.color, npc.facing, npc.walkFrame, npc.accessory);
+  drawPlayerAndUI();
+}
+
+function drawHawaiiPlatforms() {
+  for (const p of level4.platforms) {
+    ctx.fillStyle = 'rgba(0,0,0,0.1)'; ctx.fillRect(p.x + 3, p.y + 3, p.w, 14);
+    const pGrad = ctx.createLinearGradient(p.x, p.y, p.x, p.y + 14);
+    pGrad.addColorStop(0, '#a3e635'); pGrad.addColorStop(1, '#65a30d');
+    ctx.fillStyle = pGrad; ctx.beginPath(); ctx.roundRect(p.x, p.y, p.w, 14, 4); ctx.fill();
+    // Grass tufts on platforms
+    ctx.strokeStyle = '#4ade80'; ctx.lineWidth = 1.5;
+    for (let i = 0; i < 3; i++) {
+      const gx = p.x + 10 + i * (p.w - 20) / 2;
+      ctx.beginPath(); ctx.moveTo(gx, p.y); ctx.lineTo(gx - 3, p.y - 6); ctx.stroke();
+      ctx.beginPath(); ctx.moveTo(gx, p.y); ctx.lineTo(gx + 3, p.y - 5); ctx.stroke();
+    }
+  }
+}
+
+function drawHawaiiYarnBalls() {
+  for (const yb of level4.yarnBalls) {
+    if (yb.collected) continue;
+    const bob = Math.sin(gameTime / 400 + yb.bobPhase) * 3;
+    const yx = yb.x, yy = yb.y + bob;
+    ctx.globalAlpha = 0.25; ctx.fillStyle = yb.color;
+    ctx.beginPath(); ctx.arc(yx, yy, 18, 0, Math.PI * 2); ctx.fill(); ctx.globalAlpha = 1;
+    ctx.fillStyle = yb.color; ctx.beginPath(); ctx.arc(yx, yy, 12, 0, Math.PI * 2); ctx.fill();
+    ctx.strokeStyle = 'rgba(255,255,255,0.4)'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.arc(yx, yy, 10, 0.3, 1.8); ctx.stroke();
+    ctx.beginPath(); ctx.arc(yx, yy, 8, 2.0, 3.5); ctx.stroke();
+    ctx.fillStyle = 'rgba(255,255,255,0.6)';
+    ctx.beginPath(); ctx.arc(yx - 3, yy - 4, 3, 0, Math.PI * 2); ctx.fill();
+    ctx.strokeStyle = yb.color; ctx.lineWidth = 1.5;
+    ctx.beginPath(); ctx.moveTo(yx + 10, yy + 5);
+    ctx.quadraticCurveTo(yx + 16, yy + 12 + bob, yx + 12, yy + 18); ctx.stroke();
+  }
+}
+
+function drawHawaiiScenes(cam, W) {
+  for (const s of level4.scenes) {
+    if (s.x < cam - 250 || s.x > cam + W + 250) continue;
+    switch (s.type) {
+      case 'palm_tree': drawPalmTree(s.x); break;
+      case 'tiki_torch': drawTikiTorch(s.x); break;
+      case 'coconut_pile': drawCoconutPile(s.x); break;
+      case 'volcano': drawVolcano(s.x); break;
+      case 'beach_hut': drawBeachHut(s.x); break;
+      case 'surfboard': drawSurfboard(s.x); break;
+      case 'sea_turtle': drawSeaTurtle(s.x); break;
+      case 'flower_lei': drawFlowerLei(s.x); break;
+      case 'airport': drawAirport(s.x); break;
+    }
+  }
+}
+
+function drawPalmTree(x) {
+  const gy = GROUND_Y;
+  // Trunk (curved)
+  ctx.strokeStyle = '#92400e'; ctx.lineWidth = 10; ctx.lineCap = 'round';
+  ctx.beginPath(); ctx.moveTo(x, gy);
+  ctx.quadraticCurveTo(x + 12, gy - 50, x + 5, gy - 90); ctx.stroke();
+  // Fronds
+  ctx.strokeStyle = '#22c55e'; ctx.lineWidth = 3;
+  for (let i = 0; i < 6; i++) {
+    const angle = (i / 6) * Math.PI * 2;
+    const fx = x + 5 + Math.cos(angle) * 35;
+    const fy = gy - 90 + Math.sin(angle) * 15 - 5;
+    const sway = Math.sin(gameTime / 800 + i) * 4;
+    ctx.beginPath(); ctx.moveTo(x + 5, gy - 88);
+    ctx.quadraticCurveTo(x + 5 + Math.cos(angle) * 20, gy - 95 + Math.sin(angle) * 8, fx + sway, fy); ctx.stroke();
+    // Leaf details
+    ctx.strokeStyle = '#16a34a'; ctx.lineWidth = 2;
+    ctx.beginPath(); ctx.moveTo(x + 5, gy - 88);
+    ctx.quadraticCurveTo(x + 5 + Math.cos(angle) * 18, gy - 92 + Math.sin(angle) * 6, fx + sway - 3, fy + 3); ctx.stroke();
+    ctx.strokeStyle = '#22c55e'; ctx.lineWidth = 3;
+  }
+  // Coconuts
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.arc(x + 3, gy - 85, 4, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 9, gy - 83, 4, 0, Math.PI * 2); ctx.fill();
+}
+
+function drawTikiTorch(x) {
+  const gy = GROUND_Y;
+  // Pole
+  ctx.fillStyle = '#92400e'; ctx.fillRect(x - 3, gy - 55, 6, 55);
+  // Carved face
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(x - 5, gy - 45, 10, 15);
+  ctx.fillStyle = '#fde68a';
+  ctx.fillRect(x - 3, gy - 42, 3, 3); // left eye
+  ctx.fillRect(x + 1, gy - 42, 3, 3); // right eye
+  ctx.fillRect(x - 2, gy - 36, 5, 2); // mouth
+  // Flame
+  const flicker = Math.sin(gameTime / 100) * 3;
+  ctx.fillStyle = '#f97316';
+  ctx.beginPath(); ctx.moveTo(x - 6, gy - 55);
+  ctx.quadraticCurveTo(x, gy - 72 + flicker, x + 6, gy - 55); ctx.fill();
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.moveTo(x - 3, gy - 55);
+  ctx.quadraticCurveTo(x, gy - 66 + flicker, x + 3, gy - 55); ctx.fill();
+  // Glow
+  ctx.globalAlpha = 0.15;
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.arc(x, gy - 58, 20, 0, Math.PI * 2); ctx.fill();
+  ctx.globalAlpha = 1;
+}
+
+function drawCoconutPile(x) {
+  const gy = GROUND_Y;
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.arc(x - 5, gy - 6, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x + 5, gy - 6, 6, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(x, gy - 14, 6, 0, Math.PI * 2); ctx.fill();
+  // Coconut detail lines
+  ctx.strokeStyle = '#5c2d0e'; ctx.lineWidth = 0.8;
+  for (const cx2 of [x - 5, x + 5, x]) {
+    const cy = cx2 === x ? gy - 14 : gy - 6;
+    ctx.beginPath(); ctx.arc(cx2, cy, 4, 0.5, 2.5); ctx.stroke();
+  }
+}
+
+function drawVolcano(x) {
+  const gy = GROUND_Y;
+  // Mountain
+  ctx.fillStyle = '#57534e';
+  ctx.beginPath(); ctx.moveTo(x - 100, gy); ctx.lineTo(x - 20, gy - 120);
+  ctx.lineTo(x + 20, gy - 120); ctx.lineTo(x + 100, gy); ctx.closePath(); ctx.fill();
+  // Crater
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.ellipse(x, gy - 118, 22, 8, 0, 0, Math.PI * 2); ctx.fill();
+  // Lava glow
+  ctx.fillStyle = '#ef4444';
+  ctx.beginPath(); ctx.ellipse(x, gy - 118, 16, 5, 0, 0, Math.PI * 2); ctx.fill();
+  ctx.fillStyle = '#f97316';
+  ctx.beginPath(); ctx.ellipse(x, gy - 118, 10, 3, 0, 0, Math.PI * 2); ctx.fill();
+  // Smoke
+  ctx.fillStyle = 'rgba(120,120,120,0.3)';
+  for (let i = 0; i < 3; i++) {
+    const sx = x - 5 + Math.sin(gameTime / 400 + i * 2) * 10;
+    const sy = gy - 130 - i * 18 - Math.sin(gameTime / 300 + i) * 5;
+    ctx.beginPath(); ctx.arc(sx, sy, 8 + i * 3, 0, Math.PI * 2); ctx.fill();
+  }
+  // Lava streams
+  ctx.strokeStyle = '#ef4444'; ctx.lineWidth = 3;
+  ctx.beginPath(); ctx.moveTo(x - 8, gy - 115);
+  ctx.quadraticCurveTo(x - 40, gy - 60, x - 60, gy); ctx.stroke();
+  ctx.strokeStyle = '#f97316'; ctx.lineWidth = 2;
+  ctx.beginPath(); ctx.moveTo(x + 5, gy - 115);
+  ctx.quadraticCurveTo(x + 35, gy - 70, x + 50, gy); ctx.stroke();
+}
+
+function drawBeachHut(x) {
+  const gy = GROUND_Y;
+  // Stilts
+  ctx.fillStyle = '#92400e';
+  ctx.fillRect(x - 25, gy - 10, 5, 10);
+  ctx.fillRect(x + 20, gy - 10, 5, 10);
+  // Platform
+  ctx.fillRect(x - 30, gy - 14, 60, 5);
+  // Walls
+  ctx.fillStyle = '#fde68a';
+  ctx.fillRect(x - 25, gy - 45, 50, 32);
+  // Thatched roof
+  ctx.fillStyle = '#a16207';
+  ctx.beginPath(); ctx.moveTo(x - 35, gy - 45); ctx.lineTo(x, gy - 65);
+  ctx.lineTo(x + 35, gy - 45); ctx.closePath(); ctx.fill();
+  // Roof texture
+  ctx.strokeStyle = '#92400e'; ctx.lineWidth = 1;
+  for (let i = 0; i < 5; i++) {
+    ctx.beginPath();
+    ctx.moveTo(x - 30 + i * 12, gy - 47);
+    ctx.lineTo(x - 5 + i * 5, gy - 58);
+    ctx.stroke();
+  }
+  // Door
+  ctx.fillStyle = '#78350f';
+  ctx.beginPath(); ctx.roundRect(x - 7, gy - 35, 14, 22, [4, 4, 0, 0]); ctx.fill();
+  // Window
+  ctx.fillStyle = '#87ceeb';
+  ctx.fillRect(x + 10, gy - 38, 10, 8);
+  ctx.strokeStyle = '#92400e'; ctx.lineWidth = 1; ctx.strokeRect(x + 10, gy - 38, 10, 8);
+}
+
+function drawSurfboard(x) {
+  const gy = GROUND_Y;
+  // Board stuck in sand at angle
+  ctx.save(); ctx.translate(x, gy - 5); ctx.rotate(-0.3);
+  ctx.fillStyle = '#f472b6';
+  ctx.beginPath(); ctx.roundRect(-6, -45, 12, 45, [6, 6, 2, 2]); ctx.fill();
+  // Stripe
+  ctx.fillStyle = '#fbbf24';
+  ctx.fillRect(-4, -35, 8, 5);
+  ctx.fillStyle = '#22d3ee';
+  ctx.fillRect(-4, -25, 8, 5);
+  // Fin
+  ctx.fillStyle = '#f472b6';
+  ctx.beginPath(); ctx.moveTo(0, 0); ctx.lineTo(-4, 5); ctx.lineTo(4, 5); ctx.closePath(); ctx.fill();
+  ctx.restore();
+}
+
+function drawSeaTurtle(x) {
+  const gy = GROUND_Y;
+  const bob = Math.sin(gameTime / 600 + x) * 2;
+  // Shell
+  ctx.fillStyle = '#65a30d';
+  ctx.beginPath(); ctx.ellipse(x, gy - 8 + bob, 14, 10, 0, Math.PI, 0); ctx.fill();
+  ctx.fillStyle = '#4d7c0f';
+  ctx.beginPath(); ctx.ellipse(x, gy - 6 + bob, 14, 5, 0, 0, Math.PI); ctx.fill();
+  // Shell pattern
+  ctx.strokeStyle = '#3f6212'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.arc(x, gy - 10 + bob, 6, Math.PI, 0); ctx.stroke();
+  ctx.beginPath(); ctx.arc(x - 5, gy - 8 + bob, 4, Math.PI, 0); ctx.stroke();
+  ctx.beginPath(); ctx.arc(x + 5, gy - 8 + bob, 4, Math.PI, 0); ctx.stroke();
+  // Head
+  ctx.fillStyle = '#65a30d';
+  ctx.beginPath(); ctx.arc(x + 14, gy - 6 + bob, 5, 0, Math.PI * 2); ctx.fill();
+  // Eye
+  ctx.fillStyle = '#1f2937';
+  ctx.beginPath(); ctx.arc(x + 16, gy - 7 + bob, 1.5, 0, Math.PI * 2); ctx.fill();
+  // Flippers
+  ctx.fillStyle = '#65a30d';
+  ctx.beginPath(); ctx.ellipse(x - 8, gy - 2 + bob, 6, 3, -0.3, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.ellipse(x + 8, gy - 2 + bob, 6, 3, 0.3, 0, Math.PI * 2); ctx.fill();
+}
+
+function drawFlowerLei(x) {
+  const gy = GROUND_Y;
+  // Draped on ground
+  const colors = ['#f472b6','#fbbf24','#a78bfa','#fb923c','#34d399'];
+  for (let i = 0; i < 8; i++) {
+    const fx = x - 14 + i * 4;
+    const fy = gy - 4 + Math.sin(i * 0.8) * 2;
+    ctx.fillStyle = colors[i % colors.length];
+    ctx.beginPath(); ctx.arc(fx, fy, 3, 0, Math.PI * 2); ctx.fill();
+    // Center dot
+    ctx.fillStyle = '#fde68a';
+    ctx.beginPath(); ctx.arc(fx, fy, 1, 0, Math.PI * 2); ctx.fill();
+  }
+}
+
+function drawAirport(x) {
+  const gy = GROUND_Y;
+  // Runway
+  ctx.fillStyle = '#4b5563';
+  ctx.fillRect(x - 80, gy - 3, 160, 6);
+  ctx.strokeStyle = '#fbbf24'; ctx.lineWidth = 1; ctx.setLineDash([8, 6]);
+  ctx.beginPath(); ctx.moveTo(x - 75, gy); ctx.lineTo(x + 75, gy); ctx.stroke();
+  ctx.setLineDash([]);
+  // Terminal building
+  ctx.fillStyle = '#e5e7eb';
+  ctx.fillRect(x - 40, gy - 50, 80, 47);
+  // Control tower
+  ctx.fillStyle = '#d1d5db';
+  ctx.fillRect(x + 25, gy - 75, 14, 25);
+  ctx.fillStyle = '#bae6fd';
+  ctx.fillRect(x + 22, gy - 80, 20, 8);
+  ctx.fillStyle = '#9ca3af';
+  ctx.fillRect(x + 20, gy - 82, 24, 3);
+  // Terminal windows
+  ctx.fillStyle = '#bae6fd';
+  for (let i = 0; i < 5; i++) {
+    ctx.fillRect(x - 35 + i * 15, gy - 42, 10, 8);
+  }
+  // Terminal door
+  ctx.fillStyle = '#3b82f6';
+  ctx.fillRect(x - 8, gy - 30, 16, 27);
+  // "AIRPORT" sign
+  ctx.fillStyle = '#fff'; ctx.font = 'bold 8px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('AIRPORT', x, gy - 52);
+  // Airplane
+  const planeX = x + 60 + Math.sin(gameTime / 800) * 15;
+  const planeY = gy - 100 - Math.cos(gameTime / 800) * 8;
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.moveTo(planeX + 20, planeY);
+  ctx.lineTo(planeX - 15, planeY - 3);
+  ctx.lineTo(planeX - 20, planeY - 10);
+  ctx.lineTo(planeX - 18, planeY - 3);
+  ctx.lineTo(planeX - 25, planeY);
+  ctx.lineTo(planeX - 18, planeY + 3);
+  ctx.lineTo(planeX - 20, planeY + 8);
+  ctx.lineTo(planeX - 15, planeY + 3);
+  ctx.closePath();
+  ctx.fill();
+  // Plane windows
+  ctx.fillStyle = '#60a5fa';
+  for (let i = 0; i < 4; i++) {
+    ctx.beginPath(); ctx.arc(planeX + 5 - i * 6, planeY, 1.5, 0, Math.PI * 2); ctx.fill();
+  }
+  // Prompt glow
+  ctx.globalAlpha = 0.4 + Math.sin(gameTime / 300) * 0.2;
+  ctx.fillStyle = '#3b82f6';
+  ctx.beginPath(); ctx.arc(x, gy - 20, 25, 0, Math.PI * 2); ctx.fill();
+  ctx.globalAlpha = 1;
+}
+
+// ── Alps Draw Functions ──
+function drawAlpsSky(W, H, cycle, isNight) {
+  const dayTop = [180, 210, 240]; const nightTop = [15, 20, 40];
+  const dayBot = [230, 240, 255]; const nightBot = [30, 35, 60];
+  const skyTop = lerpColor(dayTop, nightTop, cycle);
+  const skyBot = lerpColor(dayBot, nightBot, cycle);
+  const grad = ctx.createLinearGradient(0, 0, 0, H);
+  grad.addColorStop(0, `rgb(${skyTop})`);
+  grad.addColorStop(1, `rgb(${skyBot})`);
+  ctx.fillStyle = grad; ctx.fillRect(0, 0, W, H);
+  if (isNight) drawStars(W, H, cycle);
+  drawCelestial(W, H, cycle);
+  // Distant mountain range silhouette
+  ctx.fillStyle = `rgba(${isNight ? '60,70,100' : '180,195,220'}, 0.6)`;
+  ctx.beginPath(); ctx.moveTo(0, GROUND_Y - 40);
+  for (let mx = 0; mx <= W; mx += 60) {
+    const mh = 50 + Math.sin(mx * 0.015 + 2) * 30 + Math.sin(mx * 0.007) * 20;
+    ctx.lineTo(mx, GROUND_Y - 40 - mh);
+  }
+  ctx.lineTo(W, GROUND_Y); ctx.lineTo(0, GROUND_Y); ctx.closePath(); ctx.fill();
+  // Snow peaks
+  ctx.fillStyle = `rgba(255,255,255, ${isNight ? 0.3 : 0.6})`;
+  for (let mx = 0; mx <= W; mx += 60) {
+    const mh = 50 + Math.sin(mx * 0.015 + 2) * 30 + Math.sin(mx * 0.007) * 20;
+    const peakY = GROUND_Y - 40 - mh;
+    ctx.beginPath();
+    ctx.moveTo(mx - 10, peakY + 12);
+    ctx.lineTo(mx, peakY);
+    ctx.lineTo(mx + 10, peakY + 12);
+    ctx.closePath(); ctx.fill();
+  }
+}
+
+function drawAlpsWorld(W, H, cam) {
+  const ww = getCurrentWorldW();
+  // Snow-covered ground
+  ctx.fillStyle = '#f0f9ff';
+  ctx.fillRect(0, GROUND_Y, ww, H);
+  // Snow surface with sparkle
+  const snowGrad = ctx.createLinearGradient(0, GROUND_Y, 0, GROUND_Y + 6);
+  snowGrad.addColorStop(0, '#e0f2fe');
+  snowGrad.addColorStop(1, '#f0f9ff');
+  ctx.fillStyle = snowGrad;
+  ctx.fillRect(0, GROUND_Y - 2, ww, 8);
+  // Snow sparkles
+  ctx.fillStyle = '#fff';
+  for (let sx = Math.floor((cam - 10) / 30) * 30; sx < cam + W + 10; sx += 30) {
+    const sparkle = Math.sin(gameTime / 300 + sx * 0.1) * 0.5 + 0.5;
+    ctx.globalAlpha = sparkle * 0.7;
+    ctx.beginPath(); ctx.arc(sx + 15, GROUND_Y - 1, 1.5, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+
+  // Draw pine trees (obstacles)
+  for (const tree of level5.trees) {
+    if (tree.x < cam - 100 || tree.x > cam + W + 100) continue;
+    drawAlpsPineTree(tree.x, tree.size, tree.hit);
+  }
+
+  // Draw cornices (snow ledges)
+  for (const c of level5.cornices) {
+    if (c.x < cam - 200 || c.x > cam + W + 200) continue;
+    drawCornice(c.x, c.y, c.w);
+  }
+
+  // Draw diamonds
+  for (const d of level5.diamonds) {
+    if (d.collected) continue;
+    if (d.x < cam - 50 || d.x > cam + W + 50) continue;
+    const bob = Math.sin(gameTime / 350 + d.bobPhase) * 3;
+    drawDiamond(d.x, d.y + bob);
+  }
+
+  // Chalet at the end
+  if (ALPS_WORLD_W - 150 > cam - 200 && ALPS_WORLD_W - 150 < cam + W + 200) {
+    drawChalet(ALPS_WORLD_W - 150);
+  }
+
+  for (const npc of alpsNpcs) drawKitty(npc.x, npc.y, npc.color, npc.facing, npc.walkFrame, npc.accessory);
+  drawPlayerAndUI();
+}
+
+function drawAlpsPineTree(x, size, hit) {
+  const gy = GROUND_Y;
+  const h = 50 * size;
+  // Trunk
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(x - 3 * size, gy - 10 * size, 6 * size, 10 * size);
+  // Tree layers (3 triangles stacked)
+  const treeColor = hit ? '#ef4444' : '#166534';
+  ctx.fillStyle = treeColor;
+  for (let layer = 0; layer < 3; layer++) {
+    const ly = gy - 10 * size - layer * h * 0.28;
+    const lw = (18 - layer * 4) * size;
+    const lh = h * 0.38;
+    ctx.beginPath();
+    ctx.moveTo(x, ly - lh);
+    ctx.lineTo(x - lw, ly);
+    ctx.lineTo(x + lw, ly);
+    ctx.closePath(); ctx.fill();
+  }
+  // Snow on branches
+  ctx.fillStyle = 'rgba(255,255,255,0.7)';
+  for (let layer = 0; layer < 3; layer++) {
+    const ly = gy - 10 * size - layer * h * 0.28;
+    const lw = (18 - layer * 4) * size;
+    ctx.beginPath();
+    ctx.moveTo(x - lw * 0.7, ly - 2);
+    ctx.quadraticCurveTo(x, ly - 6, x + lw * 0.7, ly - 2);
+    ctx.lineTo(x + lw * 0.5, ly);
+    ctx.quadraticCurveTo(x, ly - 3, x - lw * 0.5, ly);
+    ctx.closePath(); ctx.fill();
+  }
+}
+
+function drawCornice(x, y, w) {
+  // Snow ledge / cornice
+  ctx.fillStyle = 'rgba(0,0,0,0.08)';
+  ctx.fillRect(x + 3, y + 3, w, 18);
+  // Main snow body
+  const cGrad = ctx.createLinearGradient(x, y, x, y + 18);
+  cGrad.addColorStop(0, '#e0f2fe');
+  cGrad.addColorStop(0.5, '#f0f9ff');
+  cGrad.addColorStop(1, '#bae6fd');
+  ctx.fillStyle = cGrad;
+  ctx.beginPath(); ctx.roundRect(x, y, w, 18, 6); ctx.fill();
+  // Overhang lip (the cornice curl)
+  ctx.fillStyle = '#dbeafe';
+  ctx.beginPath();
+  ctx.moveTo(x + w, y + 4);
+  ctx.quadraticCurveTo(x + w + 12, y + 8, x + w + 5, y + 18);
+  ctx.lineTo(x + w, y + 18);
+  ctx.closePath(); ctx.fill();
+  // Top snow shine
+  ctx.fillStyle = 'rgba(255,255,255,0.5)';
+  ctx.fillRect(x + 5, y + 2, w - 10, 3);
+  // Icicles
+  ctx.fillStyle = '#bfdbfe';
+  for (let i = 0; i < 4; i++) {
+    const ix = x + 15 + i * ((w - 30) / 3);
+    const ih = 8 + Math.sin(gameTime / 500 + i) * 2;
+    ctx.beginPath();
+    ctx.moveTo(ix - 2, y + 18);
+    ctx.lineTo(ix, y + 18 + ih);
+    ctx.lineTo(ix + 2, y + 18);
+    ctx.closePath(); ctx.fill();
+  }
+}
+
+function drawDiamond(x, y) {
+  // Glowing diamond collectible
+  ctx.globalAlpha = 0.3;
+  ctx.fillStyle = '#60a5fa';
+  ctx.beginPath(); ctx.arc(x, y, 16, 0, Math.PI * 2); ctx.fill();
+  ctx.globalAlpha = 1;
+  // Diamond shape
+  ctx.fillStyle = '#3b82f6';
+  ctx.beginPath();
+  ctx.moveTo(x, y - 12);
+  ctx.lineTo(x + 8, y - 3);
+  ctx.lineTo(x, y + 10);
+  ctx.lineTo(x - 8, y - 3);
+  ctx.closePath(); ctx.fill();
+  // Top facet (lighter)
+  ctx.fillStyle = '#93c5fd';
+  ctx.beginPath();
+  ctx.moveTo(x, y - 12);
+  ctx.lineTo(x + 8, y - 3);
+  ctx.lineTo(x, y - 1);
+  ctx.lineTo(x - 8, y - 3);
+  ctx.closePath(); ctx.fill();
+  // Highlight
+  ctx.fillStyle = 'rgba(255,255,255,0.6)';
+  ctx.beginPath();
+  ctx.moveTo(x - 3, y - 10);
+  ctx.lineTo(x + 2, y - 4);
+  ctx.lineTo(x - 4, y - 4);
+  ctx.closePath(); ctx.fill();
+  // Sparkle
+  const sparkle = Math.sin(gameTime / 200 + x) * 0.5 + 0.5;
+  ctx.globalAlpha = sparkle;
+  ctx.fillStyle = '#fff';
+  ctx.beginPath(); ctx.arc(x + 4, y - 8, 2, 0, Math.PI * 2); ctx.fill();
+  ctx.globalAlpha = 1;
+}
+
+function drawChalet(x) {
+  const gy = GROUND_Y;
+  // Foundation
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(x - 45, gy - 5, 90, 5);
+  // Walls (warm wood)
+  const wallGrad = ctx.createLinearGradient(x - 40, gy - 65, x + 40, gy - 65);
+  wallGrad.addColorStop(0, '#b45309');
+  wallGrad.addColorStop(1, '#d97706');
+  ctx.fillStyle = wallGrad;
+  ctx.fillRect(x - 40, gy - 65, 80, 60);
+  // Log lines
+  ctx.strokeStyle = '#92400e'; ctx.lineWidth = 1;
+  for (let ly = gy - 60; ly < gy - 5; ly += 8) {
+    ctx.beginPath(); ctx.moveTo(x - 38, ly); ctx.lineTo(x + 38, ly); ctx.stroke();
+  }
+  // Roof
+  ctx.fillStyle = '#991b1b';
+  ctx.beginPath();
+  ctx.moveTo(x - 55, gy - 65);
+  ctx.lineTo(x, gy - 100);
+  ctx.lineTo(x + 55, gy - 65);
+  ctx.closePath(); ctx.fill();
+  // Snow on roof
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.moveTo(x - 55, gy - 65);
+  ctx.lineTo(x, gy - 100);
+  ctx.lineTo(x + 55, gy - 65);
+  ctx.lineTo(x + 50, gy - 62);
+  ctx.quadraticCurveTo(x, gy - 92, x - 50, gy - 62);
+  ctx.closePath(); ctx.fill();
+  // Snow overhang
+  ctx.fillStyle = '#e0f2fe';
+  ctx.beginPath();
+  ctx.moveTo(x - 55, gy - 65);
+  ctx.quadraticCurveTo(x - 58, gy - 58, x - 52, gy - 58);
+  ctx.lineTo(x - 50, gy - 65);
+  ctx.closePath(); ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(x + 55, gy - 65);
+  ctx.quadraticCurveTo(x + 58, gy - 58, x + 52, gy - 58);
+  ctx.lineTo(x + 50, gy - 65);
+  ctx.closePath(); ctx.fill();
+  // Door
+  ctx.fillStyle = '#451a03';
+  ctx.beginPath(); ctx.roundRect(x - 10, gy - 40, 20, 35, [4, 4, 0, 0]); ctx.fill();
+  ctx.fillStyle = '#fbbf24';
+  ctx.beginPath(); ctx.arc(x + 5, gy - 22, 2, 0, Math.PI * 2); ctx.fill();
+  // Windows
+  ctx.fillStyle = '#fef3c7';
+  ctx.fillRect(x - 35, gy - 55, 16, 14);
+  ctx.fillRect(x + 18, gy - 55, 16, 14);
+  // Window glow
+  ctx.globalAlpha = 0.3;
+  ctx.fillStyle = '#fbbf24';
+  ctx.fillRect(x - 35, gy - 55, 16, 14);
+  ctx.fillRect(x + 18, gy - 55, 16, 14);
+  ctx.globalAlpha = 1;
+  // Window frames
+  ctx.strokeStyle = '#78350f'; ctx.lineWidth = 1.5;
+  ctx.strokeRect(x - 35, gy - 55, 16, 14);
+  ctx.strokeRect(x + 18, gy - 55, 16, 14);
+  ctx.beginPath(); ctx.moveTo(x - 27, gy - 55); ctx.lineTo(x - 27, gy - 41); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(x + 26, gy - 55); ctx.lineTo(x + 26, gy - 41); ctx.stroke();
+  // Chimney
+  ctx.fillStyle = '#78350f';
+  ctx.fillRect(x + 20, gy - 95, 12, 20);
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(x + 18, gy - 97, 16, 4);
+  // Smoke
+  ctx.fillStyle = 'rgba(200,200,200,0.4)';
+  for (let i = 0; i < 3; i++) {
+    const sx = x + 26 + Math.sin(gameTime / 400 + i * 2) * 6;
+    const sy = gy - 100 - i * 14 - Math.sin(gameTime / 300 + i) * 4;
+    ctx.beginPath(); ctx.arc(sx, sy, 5 + i * 2, 0, Math.PI * 2); ctx.fill();
+  }
+  // "FINISH" banner
+  ctx.fillStyle = '#dc2626'; ctx.font = 'bold 10px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('FINISH', x, gy - 105);
+}
+
+function drawSurfingScene(cam, W, H) {
+  const cx = cam + W / 2;
+  const cy = GROUND_Y - 20;
+  // Sky
+  const grad = ctx.createLinearGradient(cam, 0, cam, cy - 60);
+  grad.addColorStop(0, '#38bdf8'); grad.addColorStop(1, '#7dd3fc');
+  ctx.fillStyle = grad; ctx.fillRect(cam, 0, W, cy - 60);
+  // Ocean
+  ctx.fillStyle = '#0284c7'; ctx.fillRect(cam, cy - 60, W, H);
+  // Animated waves
+  ctx.strokeStyle = 'rgba(255,255,255,0.3)'; ctx.lineWidth = 3;
+  for (let i = 0; i < 12; i++) {
+    const wx = cx - 250 + i * 45 + Math.sin(gameTime / 300 + i) * 15;
+    const wy = cy - 30 + Math.sin(gameTime / 350 + i * 0.7) * 8;
+    ctx.beginPath(); ctx.moveTo(wx, wy);
+    ctx.quadraticCurveTo(wx + 15, wy - 8, wx + 30, wy); ctx.stroke();
+  }
+  // Big wave behind kitty
+  ctx.fillStyle = '#0369a1';
+  ctx.beginPath(); ctx.moveTo(cx - 100, cy);
+  ctx.quadraticCurveTo(cx - 50, cy - 50, cx, cy - 40);
+  ctx.quadraticCurveTo(cx + 50, cy - 50, cx + 100, cy);
+  ctx.lineTo(cx + 100, cy + 40); ctx.lineTo(cx - 100, cy + 40); ctx.closePath(); ctx.fill();
+  // Wave foam
+  ctx.strokeStyle = '#bae6fd'; ctx.lineWidth = 3;
+  ctx.beginPath(); ctx.moveTo(cx - 100, cy);
+  ctx.quadraticCurveTo(cx - 50, cy - 50, cx, cy - 40);
+  ctx.quadraticCurveTo(cx + 50, cy - 50, cx + 100, cy); ctx.stroke();
+  // Surfboard under kitty
+  ctx.fillStyle = '#f472b6';
+  ctx.save(); ctx.translate(cx, cy - 15);
+  ctx.rotate(Math.sin(gameTime / 400) * 0.1);
+  ctx.beginPath(); ctx.roundRect(-20, -3, 40, 6, 3); ctx.fill();
+  ctx.fillStyle = '#fbbf24'; ctx.fillRect(-12, -2, 6, 4);
+  ctx.fillStyle = '#22d3ee'; ctx.fillRect(6, -2, 6, 4);
+  ctx.restore();
+  // Kitty on surfboard
+  const kittyBob = Math.sin(gameTime / 400) * 3;
+  drawKitty(cx, cy - 20 + kittyBob, player.color, 1, Math.floor(gameTime / 200) % 4, 'horn');
+  // Splash effects
+  ctx.fillStyle = '#bae6fd';
+  for (let i = 0; i < 8; i++) {
+    ctx.globalAlpha = 0.4 + Math.sin(gameTime / 200 + i * 1.2) * 0.3;
+    const sx = cx - 30 + Math.cos(gameTime / 250 + i * 0.9) * 50;
+    const sy = cy - 5 + Math.sin(gameTime / 200 + i * 1.5) * 10;
+    ctx.beginPath(); ctx.arc(sx, sy, 2.5, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = '#fff'; ctx.font = 'bold 18px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('Cowabunga!', cx, cy - 90);
+  ctx.font = '13px system-ui'; ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  ctx.fillText('Press S to paddle back', cx, cy + 70);
+}
+
+function drawKitty(x, y, color, facing, walkFrame, accessory) {
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.scale(facing, 1);
+
+  const bounce = walkFrame % 2 === 1 ? -2 : 0;
+
+  // Body
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.ellipse(0, -12 + bounce, 16, 14, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Head
+  ctx.beginPath();
+  ctx.arc(0, -30 + bounce, 14, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Ears
+  ctx.beginPath();
+  ctx.moveTo(-10, -40 + bounce);
+  ctx.lineTo(-6, -50 + bounce);
+  ctx.lineTo(-2, -40 + bounce);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(2, -40 + bounce);
+  ctx.lineTo(6, -50 + bounce);
+  ctx.lineTo(10, -40 + bounce);
+  ctx.fill();
+
+  // Inner ears
+  ctx.fillStyle = '#fda4af';
+  ctx.beginPath();
+  ctx.moveTo(-8, -41 + bounce);
+  ctx.lineTo(-6, -47 + bounce);
+  ctx.lineTo(-4, -41 + bounce);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(4, -41 + bounce);
+  ctx.lineTo(6, -47 + bounce);
+  ctx.lineTo(8, -41 + bounce);
+  ctx.fill();
+
+  // Eyes (big!)
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.ellipse(-5, -32 + bounce, 5, 6, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.ellipse(5, -32 + bounce, 5, 6, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Pupils
+  ctx.fillStyle = '#1e1b4b';
+  ctx.beginPath();
+  ctx.arc(-4, -31 + bounce, 2.5, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(6, -31 + bounce, 2.5, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Eye shine
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.arc(-3, -33 + bounce, 1, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(7, -33 + bounce, 1, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Mouth (happy)
+  ctx.strokeStyle = '#831843';
+  ctx.lineWidth = 1.2;
+  ctx.beginPath();
+  ctx.arc(-2, -25 + bounce, 3, 0, Math.PI);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(2, -25 + bounce, 3, 0, Math.PI);
+  ctx.stroke();
+
+  // Whiskers
+  ctx.strokeStyle = 'rgba(0,0,0,0.3)';
+  ctx.lineWidth = 0.8;
+  for (let side = -1; side <= 1; side += 2) {
+    ctx.beginPath();
+    ctx.moveTo(side * 8, -28 + bounce);
+    ctx.lineTo(side * 20, -30 + bounce);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(side * 8, -26 + bounce);
+    ctx.lineTo(side * 20, -26 + bounce);
+    ctx.stroke();
+  }
+
+  // Legs
+  ctx.fillStyle = color;
+  const legOffset = walkFrame % 4;
+  const frontLeg = Math.sin(legOffset * Math.PI / 2) * 4;
+  const backLeg = -frontLeg;
+  ctx.fillRect(-10, -2 + bounce, 6, 6 + frontLeg);
+  ctx.fillRect(4, -2 + bounce, 6, 6 + backLeg);
+
+  // Tail
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 4;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  ctx.moveTo(-14, -8 + bounce);
+  ctx.quadraticCurveTo(-24, -20 + bounce, -18, -28 + bounce + Math.sin(gameTime / 300) * 4);
+  ctx.stroke();
+
+  // Unicorn horn
+  if (accessory === 'horn') {
+    const hornGrad = ctx.createLinearGradient(0, -50 + bounce, 0, -58 + bounce);
+    hornGrad.addColorStop(0, '#fbbf24');
+    hornGrad.addColorStop(0.5, '#f472b6');
+    hornGrad.addColorStop(1, '#a78bfa');
+    ctx.fillStyle = hornGrad;
+    ctx.beginPath();
+    ctx.moveTo(-3, -43 + bounce);
+    ctx.lineTo(0, -58 + bounce);
+    ctx.lineTo(3, -43 + bounce);
+    ctx.closePath();
+    ctx.fill();
+    // Horn spiral lines
+    ctx.strokeStyle = 'rgba(255,255,255,0.5)';
+    ctx.lineWidth = 0.8;
+    for (let i = 0; i < 3; i++) {
+      const hy = -45 - i * 4 + bounce;
+      ctx.beginPath();
+      ctx.moveTo(-2, hy);
+      ctx.lineTo(2, hy - 2);
+      ctx.stroke();
+    }
+  }
+
+  // NPC accessories
+  if (accessory === 'bow') {
+    ctx.fillStyle = '#f43f5e';
+    ctx.beginPath();
+    ctx.arc(8, -42 + bounce, 4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(12, -42 + bounce, 3, 0, Math.PI * 2);
+    ctx.fill();
+  } else if (accessory === 'scarf') {
+    ctx.fillStyle = '#2563eb';
+    ctx.fillRect(-10, -18 + bounce, 20, 5);
+    ctx.fillRect(8, -18 + bounce, 4, 12);
+  } else if (accessory === 'glasses') {
+    ctx.strokeStyle = '#1e1b4b';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.arc(-5, -32 + bounce, 6, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(5, -32 + bounce, 6, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(1, -32 + bounce);
+    ctx.lineTo(-1, -32 + bounce);
+    ctx.stroke();
+  } else if (accessory === 'flower') {
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath();
+    ctx.arc(8, -44 + bounce, 3, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#f472b6';
+    for (let a = 0; a < 5; a++) {
+      const fa = (a / 5) * Math.PI * 2;
+      ctx.beginPath();
+      ctx.arc(8 + Math.cos(fa) * 4, -44 + bounce + Math.sin(fa) * 4, 2.5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  ctx.restore();
+}
+</script>
+</body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,26 +1,41 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ThemeProvider } from './context/ThemeContext'
 import Header from './components/Header'
 import Hero from './components/Hero'
 import Episodes from './components/Episodes'
 import About from './components/About'
 import Footer from './components/Footer'
+import GamePage from './pages/GamePage'
+
+function HomePage() {
+  return (
+    <>
+      <Hero />
+      <Episodes />
+      <About />
+    </>
+  )
+}
 
 function App() {
   return (
-    <ThemeProvider>
-      <div className="app">
-        <a href="#main-content" className="skip-to-content">
-          Skip to content
-        </a>
-        <Header />
-        <main id="main-content">
-          <Hero />
-          <Episodes />
-          <About />
-        </main>
-        <Footer />
-      </div>
-    </ThemeProvider>
+    <BrowserRouter>
+      <ThemeProvider>
+        <div className="app">
+          <a href="#main-content" className="skip-to-content">
+            Skip to content
+          </a>
+          <Header />
+          <main id="main-content">
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/game" element={<GamePage />} />
+            </Routes>
+          </main>
+          <Footer />
+        </div>
+      </ThemeProvider>
+    </BrowserRouter>
   )
 }
 

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -102,6 +102,28 @@
   gap: 1rem;
 }
 
+.nav-link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #7c22ce;
+  text-decoration: none;
+  padding: 0.4rem 0.85rem;
+  border-radius: 8px;
+  transition: background 0.2s, color 0.2s;
+}
+
+.nav-link:hover {
+  background: rgba(124, 34, 206, 0.1);
+}
+
+[data-theme="dark"] .nav-link {
+  color: #c084fc;
+}
+
+[data-theme="dark"] .nav-link:hover {
+  background: rgba(192, 132, 252, 0.15);
+}
+
 /* Dark mode styles */
 [data-theme="dark"] .header {
   background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f0f23 100%);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import ThemeToggle from './ThemeToggle';
 import './Header.css';
 
@@ -5,7 +6,7 @@ function Header() {
   return (
     <header className="header">
       <div className="header-content">
-        <a href="/" className="header-logo">
+        <Link to="/" className="header-logo">
           <span className="logo-icon" aria-hidden="true">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -32,8 +33,9 @@ function Header() {
             <span className="logo-title">Norah&apos;s Notes</span>
             <span className="logo-subtitle">Podcast</span>
           </span>
-        </a>
+        </Link>
         <nav className="header-nav">
+          <Link to="/game" className="nav-link">Game</Link>
           <ThemeToggle />
         </nav>
       </div>

--- a/src/pages/GamePage.css
+++ b/src/pages/GamePage.css
@@ -1,0 +1,100 @@
+.game-page {
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+
+.game-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, #ff69b4, #c084fc, #38bdf8);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 0.25rem;
+}
+
+.game-subtitle {
+  font-size: 1.1rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin-bottom: 1.5rem;
+}
+
+.game-container {
+  position: relative;
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 30px rgba(124, 34, 206, 0.2);
+  border: 2px solid rgba(147, 51, 234, 0.15);
+}
+
+.game-frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.game-controls {
+  margin-top: 1.5rem;
+  padding: 1rem 1.5rem;
+  background: rgba(124, 34, 206, 0.05);
+  border-radius: 12px;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.game-controls h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text, #1a1a2e);
+  margin-bottom: 0.75rem;
+}
+
+.controls-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  justify-content: center;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.controls-grid kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  font-family: inherit;
+  background: rgba(124, 34, 206, 0.1);
+  border-radius: 4px;
+  border: 1px solid rgba(124, 34, 206, 0.15);
+  margin-right: 4px;
+}
+
+[data-theme="dark"] .game-container {
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+  border-color: rgba(147, 51, 234, 0.3);
+}
+
+[data-theme="dark"] .game-controls {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+[data-theme="dark"] .controls-grid kbd {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+@media (max-width: 640px) {
+  .game-title {
+    font-size: 1.75rem;
+  }
+  .game-page {
+    padding: 1rem;
+  }
+}

--- a/src/pages/GamePage.jsx
+++ b/src/pages/GamePage.jsx
@@ -1,0 +1,33 @@
+import './GamePage.css'
+
+function GamePage() {
+  return (
+    <section className="game-page">
+      <h1 className="game-title">Unikittyville</h1>
+      <p className="game-subtitle">A Unicorn Kitty Adventure</p>
+      <div className="game-container">
+        <iframe
+          src="/games/unikittyville/index.html"
+          title="Unikittyville Game"
+          className="game-frame"
+          allowFullScreen
+        />
+      </div>
+      <div className="game-controls">
+        <h3>Controls</h3>
+        <div className="controls-grid">
+          <span><kbd>Arrow Keys</kbd> Move</span>
+          <span><kbd>Space</kbd> Jump</span>
+          <span><kbd>Enter</kbd> Enter/Exit</span>
+          <span><kbd>F</kbd> Fish</span>
+          <span><kbd>C</kbd> Cook/Collect</span>
+          <span><kbd>S</kbd> Swim/Surf</span>
+          <span><kbd>G</kbd> Gelato</span>
+          <span><kbd>T</kbd> Tiki Torch</span>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default GamePage


### PR DESCRIPTION
## Summary
- Adds the Unikittyville unicorn kitty game as a playable page at `/game`
- Introduces React Router (`react-router-dom`, already a dependency) for client-side navigation
- "Game" nav link added to the header
- Game embedded in a responsive iframe with controls reference
- Game audio assets uploaded to S3 separately (not in git) — deploy workflow updated to preserve them
- 4 levels: Meadow → NYC → Rome → Hawaii

## Changes
- `src/App.jsx` — Added `BrowserRouter`, `Routes`, extracted `HomePage`, added `GamePage` route
- `src/components/Header.jsx` — Switched `<a>` to `<Link>`, added "Game" nav link
- `src/components/Header.css` — Added `.nav-link` styles (light + dark theme)
- `src/pages/GamePage.jsx` — New component: iframe embed + controls grid
- `src/pages/GamePage.css` — Responsive styling with theme support
- `public/games/unikittyville/index.html` — Full game (static, served by Vite/S3)
- `.github/workflows/deploy.yml` — Exclude `games/unikittyville/assets/*` from S3 clean/delete

## Notes
- Audio files are on S3 at `games/unikittyville/assets/` — gitignored by the repo's `*.mp3` rule
- Local dev works because the MP3s exist in `public/games/unikittyville/assets/` on disk (Vite serves them)
- Direct navigation to `/game` may need a CloudFront custom error response (404 → `/index.html` with 200) if not already configured

## Test plan
- [ ] Run `npm run dev`, navigate to `/game` via header link — game loads in iframe
- [ ] Verify audio plays (background music, meow on jump, cha-ching on score)
- [ ] Verify header "Game" link and logo link work (client-side navigation, no full reload)
- [ ] Verify dark/light theme toggle works on game page
- [ ] Run `npm run build` — build succeeds, `dist/games/unikittyville/index.html` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)