### PR TITLE
Add NPC dialog, beach hut interiors, remove controls overlay

### DIFF
--- a/public/games/unikittyville/index.html
+++ b/public/games/unikittyville/index.html
@@ -88,22 +88,6 @@
     z-index: 10;
   }
   #hud span { display: flex; align-items: center; gap: 6px; }
-  #controls {
-    position: fixed;
-    bottom: 16px;
-    left: 50%;
-    transform: translateX(-50%);
-    display: none;
-    background: rgba(255,255,255,0.12);
-    backdrop-filter: blur(12px);
-    padding: 8px 20px;
-    border-radius: 14px;
-    border: 1px solid rgba(255,255,255,0.2);
-    font-size: 0.85rem;
-    color: rgba(255,255,255,0.8);
-    z-index: 10;
-    gap: 16px;
-  }
   #prompt {
     position: fixed;
     bottom: 80px;
@@ -156,15 +140,7 @@
   <span>Tiki: <b id="hudTiki">0</b></span>
   <span>Coconuts: <b id="hudCoconut">0</b></span>
   <span>Diamonds: <b id="hudDiamond">0</b></span>
-</div>
-<div id="controls">
-  <span>Arrow Keys: Move</span>
-  <span>Space: Jump</span>
-  <span>F: Fish</span>
-  <span>C: Cook</span>
-  <span>H: Honey</span>
-  <span>T: Tiki</span>
-  <span>Enter: Enter/Exit Buildings</span>
+  <span>Necklaces: <b id="hudNecklace">0</b></span>
 </div>
 <div id="prompt"></div>
 
@@ -215,6 +191,44 @@ let surfing = false;
 const TIKI_POSITIONS = [600, 1400, 2200, 3000, 3800];
 const COCONUT_POSITIONS = [400, 1200, 2000, 2800, 3600, 4400];
 const SURF_POS = { x: 1800 };
+// Beach hut interiors (Hawaii)
+let insideBeachHut = false;
+let beachHutType = ''; // 'necklace' or 'hula'
+const BEACH_HUT_POSITIONS = [1000, 3400]; // matches level4 scenes
+let necklaceMaking = { active: false, progress: 0, stage: 'idle', count: 0 };
+let hulaTimer = 0;
+let necklaceCount = 0;
+
+// NPC dialog system
+const NPC_TALK_RANGE = 60;
+let activeSpeechBubbles = []; // { npc, text, life }
+const npcDialogs = [
+  "Did you know unicorns invented rainbows?",
+  "I once caught a fish THIS big! Well, maybe this big...",
+  "Meow! I mean... neigh? I'm confused about what I am!",
+  "Want to hear a joke? Why did the unicorn cross the road? To get to the sparkle side!",
+  "My horn gets great WiFi reception!",
+  "I tried to cook bacon but I kept burning my whiskers...",
+  "What's a unicorn cat's favorite day? Caturday!",
+  "I put glitter in everything. EVERYTHING.",
+  "Why don't unicorn kitties ever get lost? They always follow the rainbow!",
+  "My tail is extra fluffy today, don't you think?",
+  "What do you call a magical cat? A purr-nicorn!",
+  "I dreamed I was chasing a laser pointer made of starlight...",
+  "Knock knock! Who's there? Unicorn. Unicorn who? Unicorn-t stop me from being fabulous!",
+  "Have you tried the gelato in Rome? Magnifico!",
+  "Fun fact: my sparkles are 100% organic and free-range!",
+  "What's a unicorn kitty's favorite music? Horn sections!",
+  "I'm not lazy, I'm on energy-saving mode!",
+  "My horoscope said I'd meet someone sparkly today... that's YOU!",
+  "Why was the unicorn kitty a good musician? It had perfect pitch and purrfect timing!",
+  "I've been practicing my surfing. Only fell off 47 times today!",
+  "This place reminds me of a dream I had... but with more fish.",
+  "Did you just see that rainbow? I made that. You're welcome.",
+  "What do unicorn kitties eat for breakfast? Lucky Charms, obviously!",
+  "I tried yoga once. Downward cat was easy, but unicorn pose? Impossible.",
+];
+
 let popups = []; // floating score popups
 let keys = {};
 let lastMeowTime = 0;
@@ -568,6 +582,12 @@ function completeTransition() {
   swimming = false;
   surfing = false;
   skiing = false;
+  insideBeachHut = false;
+  beachHutType = '';
+  necklaceMaking.stage = 'idle';
+  necklaceMaking.progress = 0;
+  hulaTimer = 0;
+  activeSpeechBubbles = [];
   pizzaMaking.stage = 'idle';
   pizzaMaking.progress = 0;
 }
@@ -877,7 +897,6 @@ function startGame() {
   playerName = name || 'Sparkle';
   document.getElementById('startScreen').style.display = 'none';
   document.getElementById('hud').style.display = 'flex';
-  document.getElementById('controls').style.display = 'flex';
   document.getElementById('hudName').textContent = playerName;
   initMeows();
   // Start music (requires user gesture, which the click/enter provides)
@@ -958,6 +977,26 @@ function update(dt) {
 
   if (surfing) {
     if (keys['KeyS']) { keys['KeyS'] = false; surfing = false; }
+    return;
+  }
+
+  if (insideBeachHut) {
+    if (beachHutType === 'necklace') {
+      updateNecklaceMinigame(dt);
+      if (keys['Enter'] && necklaceMaking.stage === 'idle') {
+        keys['Enter'] = false;
+        insideBeachHut = false;
+        beachHutType = '';
+      }
+    } else if (beachHutType === 'hula') {
+      hulaTimer += dt;
+      if (keys['Enter']) {
+        keys['Enter'] = false;
+        insideBeachHut = false;
+        beachHutType = '';
+        hulaTimer = 0;
+      }
+    }
     return;
   }
 
@@ -1245,6 +1284,7 @@ function update(dt) {
   let nearCoconut = false;
   let nearSurf = false;
   let nearAirport = false;
+  let nearBeachHut = false;
   if (currentLevel === 4) {
     // Tiki torches
     for (const tx of TIKI_POSITIONS) {
@@ -1282,8 +1322,21 @@ function update(dt) {
         surfing = true;
       }
     }
+    // Beach hut entry
+    for (let hi = 0; hi < BEACH_HUT_POSITIONS.length; hi++) {
+      if (Math.abs(player.x - BEACH_HUT_POSITIONS[hi]) < 45) {
+        nearBeachHut = true;
+        if (keys['Enter'] && !insideBeachHut) {
+          keys['Enter'] = false;
+          insideBeachHut = true;
+          beachHutType = hi === 0 ? 'necklace' : 'hula';
+          hulaTimer = 0;
+        }
+        break;
+      }
+    }
     // Airport → Alps
-    if (Math.abs(player.x - AIRPORT_POS.x) < 55) {
+    if (!nearBeachHut && Math.abs(player.x - AIRPORT_POS.x) < 55) {
       nearAirport = true;
       if (keys['Enter']) {
         keys['Enter'] = false;
@@ -1376,6 +1429,32 @@ function update(dt) {
     }
   }
 
+  // NPC talk — Q key to chat with nearby NPCs
+  let nearNpc = false;
+  for (const npc of activeNpcs) {
+    if (Math.abs(player.x - npc.x) < NPC_TALK_RANGE) {
+      nearNpc = true;
+      if (keys['KeyQ']) {
+        keys['KeyQ'] = false;
+        // Don't spam — only if this NPC isn't already talking
+        const alreadyTalking = activeSpeechBubbles.some(b => b.npc === npc);
+        if (!alreadyTalking) {
+          const text = npcDialogs[Math.floor(Math.random() * npcDialogs.length)];
+          activeSpeechBubbles.push({ npc, text, life: 4000 });
+          // Face the player
+          npc.facing = player.x < npc.x ? -1 : 1;
+        }
+      }
+      break;
+    }
+  }
+
+  // Update speech bubbles
+  for (let i = activeSpeechBubbles.length - 1; i >= 0; i--) {
+    activeSpeechBubbles[i].life -= dt;
+    if (activeSpeechBubbles[i].life <= 0) activeSpeechBubbles.splice(i, 1);
+  }
+
   // Popups
   for (let i = popups.length - 1; i >= 0; i--) {
     popups[i].y -= 1;
@@ -1395,10 +1474,11 @@ function update(dt) {
   document.getElementById('hudHoney').textContent = honeyCount;
   document.getElementById('hudTiki').textContent = tikiCount;
   document.getElementById('hudCoconut').textContent = coconutCount;
+  document.getElementById('hudNecklace').textContent = necklaceCount;
   document.getElementById('hudDiamond').textContent = diamondCount;
 
   // Prompt
-  updatePrompt(inPond, nearGrill, nearHouse, nearCamper, nearWindmill, nearBeehive, nearPizza, nearHotdog, nearPark, nearTaxi, nearFountain, nearGelato, nearPantheonDoor, nearFiat, nearTiki, nearCoconut, nearSurf, nearAirport, nearChalet);
+  updatePrompt(inPond, nearGrill, nearHouse, nearCamper, nearWindmill, nearBeehive, nearPizza, nearHotdog, nearPark, nearTaxi, nearFountain, nearGelato, nearPantheonDoor, nearFiat, nearTiki, nearCoconut, nearSurf, nearAirport, nearChalet, nearNpc, nearBeachHut);
 }
 
 function getGroundLevel(x) {
@@ -1467,10 +1547,76 @@ function updatePizzaMinigame(dt) {
   document.getElementById('hudPizza').textContent = pizzaMaking.pizzaCount;
 }
 
-function updatePrompt(inPond, nearGrill, nearHouse, nearCamper, nearWindmill, nearBeehive, nearPizza, nearHotdog, nearPark, nearTaxi, nearFountain, nearGelato, nearPantheonDoor, nearFiat, nearTiki, nearCoconut, nearSurf, nearAirport, nearChalet) {
+function updateNecklaceMinigame(dt) {
+  if (necklaceMaking.stage === 'idle') {
+    if (keys['KeyC']) {
+      keys['KeyC'] = false;
+      necklaceMaking.stage = 'collect';
+      necklaceMaking.progress = 0;
+    }
+  } else if (necklaceMaking.stage === 'collect') {
+    necklaceMaking.progress += dt;
+    if (keys['KeyC'] && necklaceMaking.progress > 1000) {
+      keys['KeyC'] = false;
+      necklaceMaking.stage = 'string';
+      necklaceMaking.progress = 0;
+    }
+  } else if (necklaceMaking.stage === 'string') {
+    necklaceMaking.progress += dt;
+    if (keys['KeyC'] && necklaceMaking.progress > 1000) {
+      keys['KeyC'] = false;
+      necklaceMaking.stage = 'polish';
+      necklaceMaking.progress = 0;
+    }
+  } else if (necklaceMaking.stage === 'polish') {
+    necklaceMaking.progress += dt;
+    if (keys['KeyC']) {
+      keys['KeyC'] = false;
+      if (necklaceMaking.progress >= 2500 && necklaceMaking.progress < 4000) {
+        necklaceCount++;
+        score += 20;
+        addPopup(player.x, player.y - 40, '+20 Necklace!', '#f472b6');
+        playChaChing();
+      } else if (necklaceMaking.progress < 2500) {
+        addPopup(player.x, player.y - 40, 'Not shiny enough!', '#93c5fd');
+      } else {
+        addPopup(player.x, player.y - 40, 'Over-polished!', '#ef4444');
+      }
+      necklaceMaking.stage = 'idle';
+      necklaceMaking.progress = 0;
+    }
+    if (necklaceMaking.progress >= 5500) {
+      addPopup(player.x, player.y - 40, 'Crumbled to pieces!', '#ef4444');
+      necklaceMaking.stage = 'idle';
+      necklaceMaking.progress = 0;
+    }
+  }
+  document.getElementById('hudScore').textContent = score;
+}
+
+function updatePrompt(inPond, nearGrill, nearHouse, nearCamper, nearWindmill, nearBeehive, nearPizza, nearHotdog, nearPark, nearTaxi, nearFountain, nearGelato, nearPantheonDoor, nearFiat, nearTiki, nearCoconut, nearSurf, nearAirport, nearChalet, nearNpc, nearBeachHut) {
   const el = document.getElementById('prompt');
   if (surfing) {
     el.textContent = 'Surfing the waves! Press S to get off';
+    el.style.display = 'block';
+    return;
+  }
+  if (insideBeachHut && beachHutType === 'necklace') {
+    if (necklaceMaking.stage === 'idle') {
+      el.textContent = 'Press C to make a seashell necklace! (Enter to leave)';
+    } else if (necklaceMaking.stage === 'collect') {
+      el.textContent = 'Collecting shells... Press C when ready!';
+    } else if (necklaceMaking.stage === 'string') {
+      el.textContent = 'Stringing shells... Press C to tie it off!';
+    } else if (necklaceMaking.stage === 'polish') {
+      const pct = Math.min(100, (necklaceMaking.progress / 2500) * 100);
+      el.textContent = `Polishing... ${Math.round(pct)}% — Press C when it shines!`;
+    }
+    el.style.display = 'block';
+    return;
+  }
+  if (insideBeachHut && beachHutType === 'hula') {
+    el.textContent = 'Hula dancing! Sway with the music... (Enter to leave)';
     el.style.display = 'block';
     return;
   }
@@ -1578,6 +1724,12 @@ function updatePrompt(inPond, nearGrill, nearHouse, nearCamper, nearWindmill, ne
   } else if (currentLevel === 5) {
     el.textContent = 'Ski downhill! Dodge trees, jump cornices, collect diamonds!';
     el.style.display = 'block';
+  } else if (nearBeachHut) {
+    el.textContent = 'Press Enter to enter the beach hut!';
+    el.style.display = 'block';
+  } else if (nearNpc) {
+    el.textContent = 'Press Q to talk!';
+    el.style.display = 'block';
   } else if (currentLevel === 1 && Math.abs(player.x - BRIDGE_PORTAL.x) < 60) {
     el.textContent = 'Press Enter to travel to NYC!';
     el.style.display = 'block';
@@ -1633,6 +1785,10 @@ function draw() {
     drawSwimmingScene(cam, W, H);
   } else if (surfing) {
     drawSurfingScene(cam, W, H);
+  } else if (insideBeachHut && beachHutType === 'necklace') {
+    drawNecklaceInterior(cam, W, H);
+  } else if (insideBeachHut && beachHutType === 'hula') {
+    drawHulaInterior(cam, W, H);
   } else if (currentLevel === 1) {
     drawLevel1World(W, H, cam, cycle, isNight);
   } else if (currentLevel === 2) {
@@ -1761,6 +1917,9 @@ function drawPlayerAndUI() {
     ctx.fillText(p.text, p.x, p.y);
     ctx.globalAlpha = 1;
   }
+
+  // Draw speech bubbles above NPCs
+  drawSpeechBubbles();
 }
 
 function drawLevelTransition(W, H) {
@@ -4352,6 +4511,220 @@ function drawSurfingScene(cam, W, H) {
   ctx.fillText('Cowabunga!', cx, cy - 90);
   ctx.font = '13px system-ui'; ctx.fillStyle = 'rgba(255,255,255,0.8)';
   ctx.fillText('Press S to paddle back', cx, cy + 70);
+}
+
+// ── Speech Bubbles ──
+function drawSpeechBubbles() {
+  for (const bubble of activeSpeechBubbles) {
+    const npc = bubble.npc;
+    const alpha = Math.min(1, bubble.life / 800);
+    ctx.globalAlpha = alpha;
+
+    // Word-wrap the text
+    ctx.font = '11px system-ui';
+    const maxWidth = 160;
+    const words = bubble.text.split(' ');
+    const lines = [];
+    let currentLine = '';
+    for (const word of words) {
+      const testLine = currentLine ? currentLine + ' ' + word : word;
+      if (ctx.measureText(testLine).width > maxWidth) {
+        lines.push(currentLine);
+        currentLine = word;
+      } else {
+        currentLine = testLine;
+      }
+    }
+    if (currentLine) lines.push(currentLine);
+
+    const lineHeight = 14;
+    const padX = 10, padY = 6;
+    const boxW = Math.min(maxWidth + padX * 2, Math.max(...lines.map(l => ctx.measureText(l).width)) + padX * 2);
+    const boxH = lines.length * lineHeight + padY * 2;
+    const bx = npc.x - boxW / 2;
+    const by = npc.y - 70 - boxH;
+
+    // Bubble background
+    ctx.fillStyle = 'rgba(255,255,255,0.95)';
+    ctx.beginPath(); ctx.roundRect(bx, by, boxW, boxH, 8); ctx.fill();
+    ctx.strokeStyle = 'rgba(0,0,0,0.15)'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.roundRect(bx, by, boxW, boxH, 8); ctx.stroke();
+
+    // Tail triangle
+    ctx.fillStyle = 'rgba(255,255,255,0.95)';
+    ctx.beginPath();
+    ctx.moveTo(npc.x - 6, by + boxH);
+    ctx.lineTo(npc.x, by + boxH + 8);
+    ctx.lineTo(npc.x + 6, by + boxH);
+    ctx.fill();
+
+    // Text
+    ctx.fillStyle = '#1f2937';
+    ctx.textAlign = 'center';
+    for (let i = 0; i < lines.length; i++) {
+      ctx.fillText(lines[i], npc.x, by + padY + 11 + i * lineHeight);
+    }
+    ctx.globalAlpha = 1;
+  }
+}
+
+// ── Beach Hut Interiors ──
+function drawNecklaceInterior(cam, W, H) {
+  const cx = cam + W / 2;
+  const cy = GROUND_Y - 60;
+  // Wooden hut interior
+  ctx.fillStyle = '#d4a574'; ctx.fillRect(cam, 0, W, H);
+  // Floor
+  ctx.fillStyle = '#c2956b'; ctx.fillRect(cam, cy + 40, W, H);
+  // Floor planks
+  ctx.strokeStyle = '#a0784e'; ctx.lineWidth = 1;
+  for (let fx = cam; fx < cam + W; fx += 30) {
+    ctx.beginPath(); ctx.moveTo(fx, cy + 40); ctx.lineTo(fx, H); ctx.stroke();
+  }
+  // Workbench
+  ctx.fillStyle = '#8B6914'; ctx.fillRect(cx - 80, cy - 10, 160, 12);
+  ctx.fillRect(cx - 75, cy + 2, 8, 40);
+  ctx.fillRect(cx + 67, cy + 2, 8, 40);
+  // Shells on bench
+  const shellColors = ['#fda4af','#fbcfe8','#e9d5ff','#bae6fd','#fef08a'];
+  for (let i = 0; i < 8; i++) {
+    const sx = cx - 60 + i * 17;
+    ctx.fillStyle = shellColors[i % shellColors.length];
+    ctx.beginPath();
+    ctx.ellipse(sx, cy - 14, 6, 4, 0, Math.PI, 0); ctx.fill();
+    ctx.strokeStyle = 'rgba(0,0,0,0.2)'; ctx.lineWidth = 0.5;
+    ctx.beginPath();
+    for (let r = 0; r < 3; r++) {
+      ctx.arc(sx, cy - 14, 3 + r * 1.5, Math.PI + 0.3, Math.PI * 2 - 0.3);
+    }
+    ctx.stroke();
+  }
+  // Progress display for current stage
+  if (necklaceMaking.stage !== 'idle') {
+    const stageLabel = necklaceMaking.stage === 'collect' ? 'Collecting shells...' :
+                       necklaceMaking.stage === 'string' ? 'Stringing together...' : 'Polishing...';
+    ctx.fillStyle = '#fff'; ctx.font = 'bold 16px system-ui'; ctx.textAlign = 'center';
+    ctx.fillText(stageLabel, cx, cy - 50);
+    // Progress bar
+    const barW = 140, barH = 12;
+    const maxT = necklaceMaking.stage === 'polish' ? 4000 : 1500;
+    const pct = Math.min(1, necklaceMaking.progress / maxT);
+    ctx.fillStyle = 'rgba(0,0,0,0.3)';
+    ctx.beginPath(); ctx.roundRect(cx - barW / 2, cy - 40, barW, barH, 4); ctx.fill();
+    const barColor = necklaceMaking.stage === 'polish' ?
+      (pct > 0.625 && pct < 1 ? '#22c55e' : pct >= 1 ? '#ef4444' : '#fbbf24') : '#3b82f6';
+    ctx.fillStyle = barColor;
+    ctx.beginPath(); ctx.roundRect(cx - barW / 2, cy - 40, barW * pct, barH, 4); ctx.fill();
+  }
+  // Necklace display (if making one)
+  if (necklaceMaking.stage === 'string' || necklaceMaking.stage === 'polish') {
+    ctx.strokeStyle = '#a8a29e'; ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(cx, cy + 10, 25, Math.PI + 0.3, -0.3);
+    ctx.stroke();
+    const numBeads = necklaceMaking.stage === 'polish' ? 7 : Math.min(7, Math.floor(necklaceMaking.progress / 150));
+    for (let i = 0; i < numBeads; i++) {
+      const angle = Math.PI + 0.3 + (i / 6) * (Math.PI - 0.6);
+      const bx = cx + Math.cos(angle) * 25;
+      const by2 = cy + 10 + Math.sin(angle) * 25;
+      ctx.fillStyle = shellColors[i % shellColors.length];
+      ctx.beginPath(); ctx.arc(bx, by2, 4, 0, Math.PI * 2); ctx.fill();
+    }
+  }
+  // Hanging finished necklaces on wall
+  for (let n = 0; n < Math.min(necklaceCount, 5); n++) {
+    const nx = cx - 100 + n * 50;
+    ctx.strokeStyle = '#d6d3d1'; ctx.lineWidth = 1.5;
+    ctx.beginPath(); ctx.arc(nx, cy - 80, 15, 0.3, Math.PI - 0.3); ctx.stroke();
+    for (let b = 0; b < 5; b++) {
+      const a = 0.3 + (b / 4) * (Math.PI - 0.6);
+      ctx.fillStyle = shellColors[b]; ctx.beginPath();
+      ctx.arc(nx + Math.cos(a) * 15, cy - 80 + Math.sin(a) * 15, 3, 0, Math.PI * 2); ctx.fill();
+    }
+  }
+  ctx.fillStyle = '#fff'; ctx.font = 'bold 18px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('Seashell Necklace Workshop', cx, cy - 110);
+  ctx.font = '13px system-ui'; ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  ctx.fillText(necklaceMaking.stage === 'idle' ? 'Press C to start, Enter to leave' : 'Press C at the right time!', cx, cy + 100);
+  drawKitty(cx, cy + 40, player.color, 1, 0, 'horn');
+}
+
+function drawHulaInterior(cam, W, H) {
+  const cx = cam + W / 2;
+  const cy = GROUND_Y - 40;
+  // Outdoor dance floor with tiki torches
+  const grad = ctx.createLinearGradient(cam, 0, cam, cy - 80);
+  grad.addColorStop(0, '#f97316'); grad.addColorStop(1, '#fbbf24');
+  ctx.fillStyle = grad; ctx.fillRect(cam, 0, W, cy - 80);
+  // Sandy floor
+  ctx.fillStyle = '#fde68a'; ctx.fillRect(cam, cy - 80, W, H);
+  // Wooden dance floor
+  ctx.fillStyle = '#a16207';
+  ctx.beginPath(); ctx.roundRect(cx - 120, cy - 20, 240, 100, 6); ctx.fill();
+  ctx.strokeStyle = '#92400e'; ctx.lineWidth = 1;
+  for (let fx = cx - 115; fx < cx + 115; fx += 20) {
+    ctx.beginPath(); ctx.moveTo(fx, cy - 20); ctx.lineTo(fx, cy + 80); ctx.stroke();
+  }
+  // Tiki torches flanking the floor
+  for (const side of [-1, 1]) {
+    const tx = cx + side * 140;
+    ctx.fillStyle = '#92400e'; ctx.fillRect(tx - 3, cy - 60, 6, 80);
+    const flicker = Math.sin(gameTime / 100 + side) * 3;
+    ctx.fillStyle = '#f97316';
+    ctx.beginPath(); ctx.moveTo(tx - 5, cy - 60);
+    ctx.quadraticCurveTo(tx, cy - 75 + flicker, tx + 5, cy - 60); ctx.fill();
+    ctx.fillStyle = '#fbbf24';
+    ctx.beginPath(); ctx.moveTo(tx - 3, cy - 60);
+    ctx.quadraticCurveTo(tx, cy - 70 + flicker, tx + 3, cy - 60); ctx.fill();
+  }
+  // Dancing NPC kitties
+  const hulaColors = ['#fda4af','#86efac','#c4b5fd'];
+  const hulaSway = Math.sin(hulaTimer / 400) * 8;
+  for (let i = 0; i < 3; i++) {
+    const dx = cx - 60 + i * 60;
+    const dy = cy + 20;
+    const sway = Math.sin(hulaTimer / 400 + i * 1.2) * 6;
+    ctx.save();
+    ctx.translate(dx + sway, dy);
+    ctx.rotate(Math.sin(hulaTimer / 500 + i) * 0.1);
+    ctx.translate(-(dx + sway), -dy);
+    drawKitty(dx + sway, dy, hulaColors[i], 1, Math.floor(hulaTimer / 200 + i) % 4, 'flower');
+    // Grass skirt
+    ctx.fillStyle = '#22c55e';
+    for (let g = 0; g < 6; g++) {
+      const gx = dx + sway - 8 + g * 3;
+      const gy = dy - 2;
+      const gSway = Math.sin(hulaTimer / 200 + g * 0.5) * 2;
+      ctx.fillRect(gx + gSway, gy, 2, 8);
+    }
+    ctx.restore();
+  }
+  // Player kitty dancing too!
+  const playerSway = Math.sin(hulaTimer / 400 + 3) * 6;
+  drawKitty(cx + playerSway, cy + 50, player.color, 1, Math.floor(hulaTimer / 200) % 4, 'horn');
+  // Player grass skirt
+  ctx.fillStyle = '#22c55e';
+  for (let g = 0; g < 6; g++) {
+    const gx = cx + playerSway - 8 + g * 3;
+    const gSway = Math.sin(hulaTimer / 200 + g * 0.5) * 2;
+    ctx.fillRect(gx + gSway, cy + 48, 2, 8);
+  }
+  // Flower lei particles floating
+  const leiColors = ['#f472b6','#fbbf24','#a78bfa','#fb923c','#34d399'];
+  for (let i = 0; i < 6; i++) {
+    const fx = cx - 100 + Math.sin(hulaTimer / 600 + i * 1.1) * 120;
+    const fy = cy - 60 + Math.cos(hulaTimer / 500 + i * 0.8) * 30;
+    ctx.globalAlpha = 0.6;
+    ctx.fillStyle = leiColors[i % leiColors.length];
+    ctx.beginPath(); ctx.arc(fx, fy, 4, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = '#fde68a';
+    ctx.beginPath(); ctx.arc(fx, fy, 1.5, 0, Math.PI * 2); ctx.fill();
+  }
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = '#fff'; ctx.font = 'bold 18px system-ui'; ctx.textAlign = 'center';
+  ctx.fillText('Hula Dancing Class!', cx, cy - 100);
+  ctx.font = '13px system-ui'; ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  ctx.fillText('Feel the rhythm... Press Enter to leave', cx, cy + 100);
 }
 
 function drawKitty(x, y, color, facing, walkFrame, accessory) {

--- a/src/pages/GamePage.jsx
+++ b/src/pages/GamePage.jsx
@@ -24,6 +24,7 @@ function GamePage() {
           <span><kbd>S</kbd> Swim/Surf</span>
           <span><kbd>G</kbd> Gelato</span>
           <span><kbd>T</kbd> Tiki Torch</span>
+          <span><kbd>Q</kbd> Talk to NPCs</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- NPCs talk when you press Q nearby — 24 random jokes and fun phrases with word-wrapped speech bubbles
- Beach hut #1 (Hawaii x=1000): Seashell necklace workshop minigame (collect → string → polish timing, +20 pts)
- Beach hut #2 (Hawaii x=3400): Hula dancing class with animated NPC dancers, grass skirts, floating petals
- Removed in-game controls overlay that was covering pizza progress meter and other UI
- Necklace count added to HUD

## Test plan
- [ ] Walk near an NPC on any level, press Q — speech bubble appears with random dialog
- [ ] Walk to beach hut at x=1000 in Hawaii, press Enter — necklace workshop loads
- [ ] Press C to start necklace minigame, time the polish stage for +20 pts
- [ ] Walk to beach hut at x=3400 in Hawaii, press Enter — hula class with dancing kitties
- [ ] Verify in-game controls bar no longer appears
- [ ] Controls reference below iframe shows Q key

🤖 Generated with [Claude Code](https://claude.com/claude-code)