### PR TITLE
Convert Game nav link to Games dropdown selector

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -124,6 +124,75 @@
   background: rgba(192, 132, 252, 0.15);
 }
 
+/* Games dropdown */
+.nav-dropdown {
+  position: relative;
+}
+
+.nav-dropdown-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.nav-dropdown-caret {
+  font-size: 0.7rem;
+  line-height: 1;
+  transition: transform 0.2s;
+}
+
+.nav-dropdown-toggle[aria-expanded="true"] .nav-dropdown-caret {
+  transform: rotate(180deg);
+}
+
+.nav-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  min-width: 12rem;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  background: #fdf4ff;
+  border: 1px solid rgba(147, 51, 234, 0.15);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(124, 34, 206, 0.18);
+  z-index: 200;
+}
+
+.nav-dropdown-item {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #7c22ce;
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 7px;
+  transition: background 0.2s, color 0.2s;
+}
+
+.nav-dropdown-item:hover {
+  background: rgba(124, 34, 206, 0.1);
+}
+
+[data-theme="dark"] .nav-dropdown-menu {
+  background: #16213e;
+  border-color: rgba(192, 132, 252, 0.2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="dark"] .nav-dropdown-item {
+  color: #c084fc;
+}
+
+[data-theme="dark"] .nav-dropdown-item:hover {
+  background: rgba(192, 132, 252, 0.15);
+}
+
 /* Dark mode styles */
 [data-theme="dark"] .header {
   background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f0f23 100%);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,8 +1,44 @@
-import { Link } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import ThemeToggle from './ThemeToggle';
 import './Header.css';
 
+const GAMES = [
+  { to: '/game', label: 'Unikittyville' },
+  { to: '/vacation', label: 'England Vacation' },
+];
+
 function Header() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+  const location = useLocation();
+
+  // Close the menu when navigating to a new route.
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  // Close the menu on outside click or Escape.
+  useEffect(() => {
+    if (!menuOpen) return undefined;
+
+    function handlePointerDown(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    }
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') setMenuOpen(false);
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuOpen]);
+
   return (
     <header className="header">
       <div className="header-content">
@@ -35,8 +71,29 @@ function Header() {
           </span>
         </Link>
         <nav className="header-nav">
-          <Link to="/game" className="nav-link">Game</Link>
-          <Link to="/vacation" className="nav-link">Vacation</Link>
+          <div className="nav-dropdown" ref={menuRef}>
+            <button
+              type="button"
+              className="nav-link nav-dropdown-toggle"
+              aria-haspopup="true"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen((open) => !open)}
+            >
+              Games
+              <span className="nav-dropdown-caret" aria-hidden="true">▾</span>
+            </button>
+            {menuOpen && (
+              <ul className="nav-dropdown-menu" role="menu">
+                {GAMES.map((game) => (
+                  <li key={game.to} role="none">
+                    <Link to={game.to} className="nav-dropdown-item" role="menuitem">
+                      {game.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
           <ThemeToggle />
         </nav>
       </div>


### PR DESCRIPTION
## Summary
The site now has more than one game, so the single **Game** nav link is replaced with a **Games** dropdown selector.

- **Unikittyville** → `/game`
- **England Vacation** → `/vacation`

The dropdown closes on outside click, Escape, or route navigation, and is styled to match the existing nav (including dark mode).

## Testing
- `npx eslint src/components/Header.jsx` — clean
- `npm run build` — succeeds

Closes norahtashner.com-40j

🤖 Generated with [Claude Code](https://claude.com/claude-code)