### PR TITLE
Vacation game: offline support + polish, fix Header test

### DIFF
--- a/public/games/norahs-big-vacation/assets.js
+++ b/public/games/norahs-big-vacation/assets.js
@@ -9,26 +9,26 @@ window.NVassets = {
     music: 'assets/music/london-stroll.m4a'
   },
 
-  // ⏳ backgrounds/music ready, chapters not built yet
+  // chapters use placeholder music (reused tracks) until bespoke ones exist
   pups: {
-    bg: 'assets/images/home-richmond.png'
-    // music: TODO (cozy home / goodbye theme)
+    bg: 'assets/images/home-richmond.png',
+    music: 'assets/music/richmond-home.mp3'      // placeholder: cozy home theme
   },
   airport: {
     bg: 'assets/images/richmond-airport.png',
     music: 'assets/music/airport-music.mp3'
   },
   nyc: {
-    bg: 'assets/images/plane-ride-nyc.png'
-    // music: TODO (flight theme)
+    bg: 'assets/images/plane-ride-nyc.png',
+    music: 'assets/music/chunnel-adventure.m4a'  // placeholder: travel/adventure
   },
   overnight: {
-    bg: 'assets/images/plane-ride-night.png'
-    // music: TODO (sleepy night-flight theme)
+    bg: 'assets/images/plane-ride-night.png',
+    music: 'assets/music/leeds-castle-evening.m4a' // placeholder: calm night theme
   },
   train: {
-    bg: 'assets/images/london-train-station.png'
-    // music: TODO (train theme)
+    bg: 'assets/images/london-train-station.png',
+    music: 'assets/music/london-stroll.m4a'       // placeholder: London theme
   },
   london: {
     bg: 'assets/images/county-hall-hotel.png',
@@ -53,12 +53,12 @@ window.NVassets = {
     music: 'assets/music/paris-bakery.m4a'
   },
   home: {
-    // placeholder bg: reuse the daytime airport until a richmond-airport-evening
-    // (reunion) background is generated.
-    bg: 'assets/images/richmond-airport.png',
+    // reunion at home with the pups — reuse the cozy home scene (better than the
+    // airport for the "we're home!" beat) until a dedicated reunion bg exists.
+    bg: 'assets/images/home-richmond.png',
     music: 'assets/music/richmond-home.mp3'
   }
 
-  // ❌ still missing: a dedicated 'home' evening/reunion background, and music
-  //    for pups / nyc / overnight / train.
+  // ⚠️ placeholders in use: music for pups/nyc/overnight/train reuse existing
+  //    tracks; home reuses the home-richmond scene. Swap in bespoke assets later.
 };

--- a/public/games/norahs-big-vacation/game.js
+++ b/public/games/norahs-big-vacation/game.js
@@ -141,6 +141,26 @@
       + '  •  ' + (camileFound ? 'Camile ✓' : 'Camile …');
   }
 
+  // Swap the painted background, waiting until the image is decoded.
+  function setSceneBg(url, done) {
+    var bg = byId('bg');
+    if (!url) { bg.style.backgroundImage = 'none'; if (done) done(); return; }
+    var img = new Image();
+    img.onload = img.onerror = function () { bg.style.backgroundImage = 'url("' + url + '")'; if (done) done(); };
+    img.src = url;
+  }
+  function hideLoading() {
+    var l = byId('loading');
+    if (l && !l.classList.contains('hide')) {
+      l.classList.add('hide');
+      setTimeout(function () { if (l.parentNode) l.parentNode.removeChild(l); }, 600);
+    }
+  }
+  function preloadNext() {
+    var n = CHAPTERS[cur + 1]; if (!n) return;
+    var a = assets[n.id]; if (a && a.bg) { var im = new Image(); im.src = a.bg; }
+  }
+
   // ── Load a chapter ──
   function loadChapter(i) {
     cur = Math.max(0, Math.min(CHAPTERS.length - 1, i));
@@ -149,13 +169,18 @@
     collected = 0; total = (ch.items || []).length;
     camileFound = !!save.camiles[ch.id];
     sceneEl.style.transform = 'scale(1)';
+    sceneEl.style.opacity = '0';          // fade in once the bg is ready
     sightsBox.style.display = 'none';
 
     stage.innerHTML = art.scene(ch);
 
     var A = assets[ch.id] || {};
-    byId('bg').style.backgroundImage = A.bg ? 'url("' + A.bg + '")' : 'none';
     audio.setMusic(A.music || null);
+    setSceneBg(A.bg, function () {
+      requestAnimationFrame(function () { sceneEl.style.opacity = '1'; });
+      hideLoading();
+      preloadNext();
+    });
 
     wireHiddenCamile();
     updateProgress();

--- a/public/games/norahs-big-vacation/index.html
+++ b/public/games/norahs-big-vacation/index.html
@@ -13,6 +13,13 @@
 <!-- ════════ Game root ════════ -->
 <div id="app">
 
+  <!-- First-load splash (removed once the first scene is ready) -->
+  <div id="loading">
+    <div class="loader-ring" aria-hidden="true"></div>
+    <div class="loader-text">Norah&apos;s Big Vacation</div>
+    <div class="loader-sub">Packing the suitcase… 🧳</div>
+  </div>
+
   <!-- Scene: painted background + transparent SVG overlay. Zoomed together so
        tappable hotspots stay aligned with the artwork. -->
   <div id="scene">
@@ -67,5 +74,13 @@
 <script src="assets.js"></script>
 <script src="audio.js"></script>
 <script src="game.js"></script>
+<script>
+  // Register the offline service worker (works on a plane after one load).
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function () {
+      navigator.serviceWorker.register('sw.js').catch(function () { /* offline still fine without it */ });
+    });
+  }
+</script>
 </body>
 </html>

--- a/public/games/norahs-big-vacation/styles.css
+++ b/public/games/norahs-big-vacation/styles.css
@@ -40,8 +40,8 @@ html, body {
 #scene {
   position: absolute; inset: 0;
   transform-origin: 50% 50%;
-  transition: transform 1.1s ease;
-  will-change: transform;
+  transition: transform 1.1s ease, opacity 0.45s ease;
+  will-change: transform, opacity;
 }
 #bg {
   position: absolute; inset: 0;
@@ -293,6 +293,28 @@ html, body {
   animation: floatUp 1s ease forwards;
 }
 @keyframes floatUp { from { transform: translateY(0); opacity: 1; } to { transform: translateY(-50px); opacity: 0; } }
+
+/* ── First-load splash ── */
+#loading {
+  position: absolute; inset: 0; z-index: 60;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 14px;
+  background: linear-gradient(160deg, #2a3f73, #5b6fa6 55%, #e8a07a);
+  color: #fff; text-align: center;
+  transition: opacity 0.5s ease;
+}
+#loading.hide { opacity: 0; pointer-events: none; }
+.loader-ring {
+  width: 54px; height: 54px;
+  border: 6px solid rgba(255,255,255,0.35);
+  border-top-color: var(--gold);
+  border-radius: 50%;
+  animation: spin 0.9s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.loader-text { font-size: 1.5rem; font-weight: 800; text-shadow: 0 2px 8px rgba(0,0,0,0.3); }
+.loader-sub { font-size: 1rem; opacity: 0.9; }
 
 @media (max-width: 380px) {
   #narration { font-size: 1.02rem; }

--- a/public/games/norahs-big-vacation/sw.js
+++ b/public/games/norahs-big-vacation/sw.js
@@ -1,0 +1,71 @@
+/* sw.js — service worker for offline play (essential for a flight).
+   Precaches the whole game on first load, then serves stale-while-revalidate
+   so it works with zero network and still updates when online. */
+var CACHE = 'norahs-vacation-v1';
+var ASSETS = [
+  './', 'index.html', 'styles.css', 'art.js', 'assets.js', 'audio.js', 'game.js',
+  // backgrounds
+  'assets/images/chunnel.png',
+  'assets/images/county-hall-hotel.png',
+  'assets/images/home-richmond.png',
+  'assets/images/leeds-castle-day.png',
+  'assets/images/leeds-castle-evening.png',
+  'assets/images/london-eye-county-hall.png',
+  'assets/images/london-train-station.png',
+  'assets/images/paris-boulangerie.png',
+  'assets/images/paris-eiffel-tower.png',
+  'assets/images/plane-ride-night.png',
+  'assets/images/plane-ride-nyc.png',
+  'assets/images/richmond-airport.png',
+  // character sprites
+  'assets/images/sprites/char-norah.png',
+  'assets/images/sprites/char-camile.png',
+  'assets/images/sprites/char-mommo.png',
+  'assets/images/sprites/char-daddo.png',
+  'assets/images/sprites/char-penny.png',
+  'assets/images/sprites/char-obi.png',
+  // music
+  'assets/music/airport-music.mp3',
+  'assets/music/chunnel-adventure.m4a',
+  'assets/music/leeds-castle-day.m4a',
+  'assets/music/leeds-castle-evening.m4a',
+  'assets/music/london-stroll.m4a',
+  'assets/music/paris-bakery.m4a',
+  'assets/music/paris-eiffel-tower.m4a',
+  'assets/music/richmond-home.mp3'
+];
+
+self.addEventListener('install', function (e) {
+  e.waitUntil(
+    caches.open(CACHE).then(function (c) {
+      // cache individually so one missing file doesn't fail the whole install
+      return Promise.all(ASSETS.map(function (url) {
+        return c.add(url).catch(function () { /* skip missing */ });
+      }));
+    }).then(function () { return self.skipWaiting(); })
+  );
+});
+
+self.addEventListener('activate', function (e) {
+  e.waitUntil(
+    caches.keys().then(function (keys) {
+      return Promise.all(keys.map(function (k) { if (k !== CACHE) return caches.delete(k); }));
+    }).then(function () { return self.clients.claim(); })
+  );
+});
+
+self.addEventListener('fetch', function (e) {
+  if (e.request.method !== 'GET') return;
+  e.respondWith(
+    caches.match(e.request).then(function (cached) {
+      var network = fetch(e.request).then(function (res) {
+        if (res && res.status === 200 && res.type !== 'opaque') {
+          var copy = res.clone();
+          caches.open(CACHE).then(function (c) { c.put(e.request, copy); });
+        }
+        return res;
+      }).catch(function () { return cached; });
+      return cached || network;   // stale-while-revalidate
+    })
+  );
+});

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -1,10 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { ThemeProvider } from '../context/ThemeContext'
 import Header from './Header'
 
+// Header uses router hooks (useLocation), so wrap in a router.
 function renderWithTheme(component) {
-  return render(<ThemeProvider>{component}</ThemeProvider>)
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>{component}</ThemeProvider>
+    </MemoryRouter>
+  )
 }
 
 describe('Header', () => {

--- a/src/pages/VacationGamePage.test.jsx
+++ b/src/pages/VacationGamePage.test.jsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import VacationGamePage from './VacationGamePage'
+
+describe('VacationGamePage', () => {
+  it('renders the page section', () => {
+    render(<VacationGamePage />)
+    expect(document.querySelector('.vacay-page')).toBeInTheDocument()
+  })
+
+  it('shows the game title', () => {
+    render(<VacationGamePage />)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/Norah's Big Vacation/i)
+  })
+
+  it('embeds the standalone game in an iframe', () => {
+    render(<VacationGamePage />)
+    const frame = screen.getByTitle(/Norah's Big Vacation Game/i)
+    expect(frame).toBeInTheDocument()
+    expect(frame).toHaveAttribute('src', '/games/norahs-big-vacation/index.html')
+  })
+
+  it('includes how-to-play instructions', () => {
+    render(<VacationGamePage />)
+    expect(screen.getByText(/it's all taps/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Game
- **Offline service worker** (`sw.js`): precache + stale-while-revalidate so the game runs with zero network after one load — essential for playing on a plane.
- First-load splash, **fade transitions** between chapters, and next-chapter background preloading (no more flashes).
- **Every chapter now has music** (placeholder reuse for pups/nyc/overnight/train until bespoke tracks exist); home reunion now uses the cozy home scene instead of the airport.

## Site
- Add `VacationGamePage.test.jsx`.
- Fix pre-existing `Header.test.jsx` failure (Header now calls `useLocation()`; tests needed a `MemoryRouter`). Full suite: **58 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)